### PR TITLE
[Feat] 카카오 OAuth를 통한 로그인 및 최초 사용자 등록 기능 구현 (#5)

### DIFF
--- a/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml
+++ b/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml
@@ -100,922 +100,922 @@ performance_schema|schema||mysql.session|localhost|SELECT|G
 sys|schema||mysql.sys|localhost|TRIGGER|G</Grants>
       <ServerVersion>9.2.0</ServerVersion>
     </root>
-    <collation id="2" parent="1" name="armscii8_bin">
-      <Charset>armscii8</Charset>
-    </collation>
-    <collation id="3" parent="1" name="armscii8_general_ci">
+    <collation id="2" parent="1" name="armscii8_general_ci">
       <Charset>armscii8</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="4" parent="1" name="ascii_bin">
-      <Charset>ascii</Charset>
+    <collation id="3" parent="1" name="armscii8_bin">
+      <Charset>armscii8</Charset>
     </collation>
-    <collation id="5" parent="1" name="ascii_general_ci">
+    <collation id="4" parent="1" name="ascii_general_ci">
       <Charset>ascii</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="6" parent="1" name="big5_bin">
-      <Charset>big5</Charset>
+    <collation id="5" parent="1" name="ascii_bin">
+      <Charset>ascii</Charset>
     </collation>
-    <collation id="7" parent="1" name="big5_chinese_ci">
+    <collation id="6" parent="1" name="big5_chinese_ci">
       <Charset>big5</Charset>
       <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="7" parent="1" name="big5_bin">
+      <Charset>big5</Charset>
     </collation>
     <collation id="8" parent="1" name="binary">
       <Charset>binary</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="9" parent="1" name="cp1250_bin">
-      <Charset>cp1250</Charset>
-    </collation>
-    <collation id="10" parent="1" name="cp1250_croatian_ci">
-      <Charset>cp1250</Charset>
-    </collation>
-    <collation id="11" parent="1" name="cp1250_czech_cs">
-      <Charset>cp1250</Charset>
-    </collation>
-    <collation id="12" parent="1" name="cp1250_general_ci">
+    <collation id="9" parent="1" name="cp1250_general_ci">
       <Charset>cp1250</Charset>
       <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="10" parent="1" name="cp1250_czech_cs">
+      <Charset>cp1250</Charset>
+    </collation>
+    <collation id="11" parent="1" name="cp1250_croatian_ci">
+      <Charset>cp1250</Charset>
+    </collation>
+    <collation id="12" parent="1" name="cp1250_bin">
+      <Charset>cp1250</Charset>
     </collation>
     <collation id="13" parent="1" name="cp1250_polish_ci">
       <Charset>cp1250</Charset>
     </collation>
-    <collation id="14" parent="1" name="cp1251_bin">
+    <collation id="14" parent="1" name="cp1251_bulgarian_ci">
       <Charset>cp1251</Charset>
     </collation>
-    <collation id="15" parent="1" name="cp1251_bulgarian_ci">
+    <collation id="15" parent="1" name="cp1251_ukrainian_ci">
       <Charset>cp1251</Charset>
     </collation>
-    <collation id="16" parent="1" name="cp1251_general_ci">
+    <collation id="16" parent="1" name="cp1251_bin">
+      <Charset>cp1251</Charset>
+    </collation>
+    <collation id="17" parent="1" name="cp1251_general_ci">
       <Charset>cp1251</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="17" parent="1" name="cp1251_general_cs">
+    <collation id="18" parent="1" name="cp1251_general_cs">
       <Charset>cp1251</Charset>
     </collation>
-    <collation id="18" parent="1" name="cp1251_ukrainian_ci">
-      <Charset>cp1251</Charset>
-    </collation>
-    <collation id="19" parent="1" name="cp1256_bin">
-      <Charset>cp1256</Charset>
-    </collation>
-    <collation id="20" parent="1" name="cp1256_general_ci">
+    <collation id="19" parent="1" name="cp1256_general_ci">
       <Charset>cp1256</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="21" parent="1" name="cp1257_bin">
+    <collation id="20" parent="1" name="cp1256_bin">
+      <Charset>cp1256</Charset>
+    </collation>
+    <collation id="21" parent="1" name="cp1257_lithuanian_ci">
       <Charset>cp1257</Charset>
     </collation>
-    <collation id="22" parent="1" name="cp1257_general_ci">
+    <collation id="22" parent="1" name="cp1257_bin">
+      <Charset>cp1257</Charset>
+    </collation>
+    <collation id="23" parent="1" name="cp1257_general_ci">
       <Charset>cp1257</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="23" parent="1" name="cp1257_lithuanian_ci">
-      <Charset>cp1257</Charset>
+    <collation id="24" parent="1" name="cp850_general_ci">
+      <Charset>cp850</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="24" parent="1" name="cp850_bin">
+    <collation id="25" parent="1" name="cp850_bin">
       <Charset>cp850</Charset>
     </collation>
-    <collation id="25" parent="1" name="cp850_general_ci">
-      <Charset>cp850</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="26" parent="1" name="cp852_bin">
-      <Charset>cp852</Charset>
-    </collation>
-    <collation id="27" parent="1" name="cp852_general_ci">
+    <collation id="26" parent="1" name="cp852_general_ci">
       <Charset>cp852</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="28" parent="1" name="cp866_bin">
+    <collation id="27" parent="1" name="cp852_bin">
+      <Charset>cp852</Charset>
+    </collation>
+    <collation id="28" parent="1" name="cp866_general_ci">
+      <Charset>cp866</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="29" parent="1" name="cp866_bin">
       <Charset>cp866</Charset>
     </collation>
-    <collation id="29" parent="1" name="cp866_general_ci">
-      <Charset>cp866</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="30" parent="1" name="cp932_bin">
-      <Charset>cp932</Charset>
-    </collation>
-    <collation id="31" parent="1" name="cp932_japanese_ci">
+    <collation id="30" parent="1" name="cp932_japanese_ci">
       <Charset>cp932</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="32" parent="1" name="dec8_bin">
+    <collation id="31" parent="1" name="cp932_bin">
+      <Charset>cp932</Charset>
+    </collation>
+    <collation id="32" parent="1" name="dec8_swedish_ci">
+      <Charset>dec8</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="33" parent="1" name="dec8_bin">
       <Charset>dec8</Charset>
     </collation>
-    <collation id="33" parent="1" name="dec8_swedish_ci">
-      <Charset>dec8</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="34" parent="1" name="eucjpms_bin">
-      <Charset>eucjpms</Charset>
-    </collation>
-    <collation id="35" parent="1" name="eucjpms_japanese_ci">
+    <collation id="34" parent="1" name="eucjpms_japanese_ci">
       <Charset>eucjpms</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="36" parent="1" name="euckr_bin">
-      <Charset>euckr</Charset>
+    <collation id="35" parent="1" name="eucjpms_bin">
+      <Charset>eucjpms</Charset>
     </collation>
-    <collation id="37" parent="1" name="euckr_korean_ci">
+    <collation id="36" parent="1" name="euckr_korean_ci">
       <Charset>euckr</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="38" parent="1" name="gb18030_bin">
-      <Charset>gb18030</Charset>
+    <collation id="37" parent="1" name="euckr_bin">
+      <Charset>euckr</Charset>
     </collation>
-    <collation id="39" parent="1" name="gb18030_chinese_ci">
+    <collation id="38" parent="1" name="gb18030_chinese_ci">
       <Charset>gb18030</Charset>
       <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="39" parent="1" name="gb18030_bin">
+      <Charset>gb18030</Charset>
     </collation>
     <collation id="40" parent="1" name="gb18030_unicode_520_ci">
       <Charset>gb18030</Charset>
     </collation>
-    <collation id="41" parent="1" name="gb2312_bin">
-      <Charset>gb2312</Charset>
-    </collation>
-    <collation id="42" parent="1" name="gb2312_chinese_ci">
+    <collation id="41" parent="1" name="gb2312_chinese_ci">
       <Charset>gb2312</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="43" parent="1" name="gbk_bin">
+    <collation id="42" parent="1" name="gb2312_bin">
+      <Charset>gb2312</Charset>
+    </collation>
+    <collation id="43" parent="1" name="gbk_chinese_ci">
+      <Charset>gbk</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="44" parent="1" name="gbk_bin">
       <Charset>gbk</Charset>
     </collation>
-    <collation id="44" parent="1" name="gbk_chinese_ci">
-      <Charset>gbk</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="45" parent="1" name="geostd8_bin">
-      <Charset>geostd8</Charset>
-    </collation>
-    <collation id="46" parent="1" name="geostd8_general_ci">
+    <collation id="45" parent="1" name="geostd8_general_ci">
       <Charset>geostd8</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="47" parent="1" name="greek_bin">
+    <collation id="46" parent="1" name="geostd8_bin">
+      <Charset>geostd8</Charset>
+    </collation>
+    <collation id="47" parent="1" name="greek_general_ci">
+      <Charset>greek</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="48" parent="1" name="greek_bin">
       <Charset>greek</Charset>
     </collation>
-    <collation id="48" parent="1" name="greek_general_ci">
-      <Charset>greek</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="49" parent="1" name="hebrew_bin">
-      <Charset>hebrew</Charset>
-    </collation>
-    <collation id="50" parent="1" name="hebrew_general_ci">
+    <collation id="49" parent="1" name="hebrew_general_ci">
       <Charset>hebrew</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="51" parent="1" name="hp8_bin">
+    <collation id="50" parent="1" name="hebrew_bin">
+      <Charset>hebrew</Charset>
+    </collation>
+    <collation id="51" parent="1" name="hp8_english_ci">
+      <Charset>hp8</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="52" parent="1" name="hp8_bin">
       <Charset>hp8</Charset>
     </collation>
-    <collation id="52" parent="1" name="hp8_english_ci">
-      <Charset>hp8</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="53" parent="1" name="keybcs2_bin">
-      <Charset>keybcs2</Charset>
-    </collation>
-    <collation id="54" parent="1" name="keybcs2_general_ci">
+    <collation id="53" parent="1" name="keybcs2_general_ci">
       <Charset>keybcs2</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="55" parent="1" name="koi8r_bin">
+    <collation id="54" parent="1" name="keybcs2_bin">
+      <Charset>keybcs2</Charset>
+    </collation>
+    <collation id="55" parent="1" name="koi8r_general_ci">
+      <Charset>koi8r</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="56" parent="1" name="koi8r_bin">
       <Charset>koi8r</Charset>
     </collation>
-    <collation id="56" parent="1" name="koi8r_general_ci">
-      <Charset>koi8r</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="57" parent="1" name="koi8u_bin">
-      <Charset>koi8u</Charset>
-    </collation>
-    <collation id="58" parent="1" name="koi8u_general_ci">
+    <collation id="57" parent="1" name="koi8u_general_ci">
       <Charset>koi8u</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="59" parent="1" name="latin1_bin">
+    <collation id="58" parent="1" name="koi8u_bin">
+      <Charset>koi8u</Charset>
+    </collation>
+    <collation id="59" parent="1" name="latin1_german1_ci">
       <Charset>latin1</Charset>
     </collation>
-    <collation id="60" parent="1" name="latin1_danish_ci">
-      <Charset>latin1</Charset>
-    </collation>
-    <collation id="61" parent="1" name="latin1_general_ci">
-      <Charset>latin1</Charset>
-    </collation>
-    <collation id="62" parent="1" name="latin1_general_cs">
-      <Charset>latin1</Charset>
-    </collation>
-    <collation id="63" parent="1" name="latin1_german1_ci">
-      <Charset>latin1</Charset>
-    </collation>
-    <collation id="64" parent="1" name="latin1_german2_ci">
-      <Charset>latin1</Charset>
-    </collation>
-    <collation id="65" parent="1" name="latin1_spanish_ci">
-      <Charset>latin1</Charset>
-    </collation>
-    <collation id="66" parent="1" name="latin1_swedish_ci">
+    <collation id="60" parent="1" name="latin1_swedish_ci">
       <Charset>latin1</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="67" parent="1" name="latin2_bin">
+    <collation id="61" parent="1" name="latin1_danish_ci">
+      <Charset>latin1</Charset>
+    </collation>
+    <collation id="62" parent="1" name="latin1_german2_ci">
+      <Charset>latin1</Charset>
+    </collation>
+    <collation id="63" parent="1" name="latin1_bin">
+      <Charset>latin1</Charset>
+    </collation>
+    <collation id="64" parent="1" name="latin1_general_ci">
+      <Charset>latin1</Charset>
+    </collation>
+    <collation id="65" parent="1" name="latin1_general_cs">
+      <Charset>latin1</Charset>
+    </collation>
+    <collation id="66" parent="1" name="latin1_spanish_ci">
+      <Charset>latin1</Charset>
+    </collation>
+    <collation id="67" parent="1" name="latin2_czech_cs">
       <Charset>latin2</Charset>
     </collation>
-    <collation id="68" parent="1" name="latin2_croatian_ci">
-      <Charset>latin2</Charset>
-    </collation>
-    <collation id="69" parent="1" name="latin2_czech_cs">
-      <Charset>latin2</Charset>
-    </collation>
-    <collation id="70" parent="1" name="latin2_general_ci">
+    <collation id="68" parent="1" name="latin2_general_ci">
       <Charset>latin2</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="71" parent="1" name="latin2_hungarian_ci">
+    <collation id="69" parent="1" name="latin2_hungarian_ci">
       <Charset>latin2</Charset>
     </collation>
-    <collation id="72" parent="1" name="latin5_bin">
+    <collation id="70" parent="1" name="latin2_croatian_ci">
+      <Charset>latin2</Charset>
+    </collation>
+    <collation id="71" parent="1" name="latin2_bin">
+      <Charset>latin2</Charset>
+    </collation>
+    <collation id="72" parent="1" name="latin5_turkish_ci">
+      <Charset>latin5</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="73" parent="1" name="latin5_bin">
       <Charset>latin5</Charset>
     </collation>
-    <collation id="73" parent="1" name="latin5_turkish_ci">
-      <Charset>latin5</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="74" parent="1" name="latin7_bin">
+    <collation id="74" parent="1" name="latin7_estonian_cs">
       <Charset>latin7</Charset>
     </collation>
-    <collation id="75" parent="1" name="latin7_estonian_cs">
-      <Charset>latin7</Charset>
-    </collation>
-    <collation id="76" parent="1" name="latin7_general_ci">
+    <collation id="75" parent="1" name="latin7_general_ci">
       <Charset>latin7</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="77" parent="1" name="latin7_general_cs">
+    <collation id="76" parent="1" name="latin7_general_cs">
       <Charset>latin7</Charset>
     </collation>
-    <collation id="78" parent="1" name="macce_bin">
-      <Charset>macce</Charset>
+    <collation id="77" parent="1" name="latin7_bin">
+      <Charset>latin7</Charset>
     </collation>
-    <collation id="79" parent="1" name="macce_general_ci">
+    <collation id="78" parent="1" name="macce_general_ci">
       <Charset>macce</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="80" parent="1" name="macroman_bin">
+    <collation id="79" parent="1" name="macce_bin">
+      <Charset>macce</Charset>
+    </collation>
+    <collation id="80" parent="1" name="macroman_general_ci">
+      <Charset>macroman</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="81" parent="1" name="macroman_bin">
       <Charset>macroman</Charset>
     </collation>
-    <collation id="81" parent="1" name="macroman_general_ci">
-      <Charset>macroman</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="82" parent="1" name="sjis_bin">
-      <Charset>sjis</Charset>
-    </collation>
-    <collation id="83" parent="1" name="sjis_japanese_ci">
+    <collation id="82" parent="1" name="sjis_japanese_ci">
       <Charset>sjis</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="84" parent="1" name="swe7_bin">
+    <collation id="83" parent="1" name="sjis_bin">
+      <Charset>sjis</Charset>
+    </collation>
+    <collation id="84" parent="1" name="swe7_swedish_ci">
+      <Charset>swe7</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="85" parent="1" name="swe7_bin">
       <Charset>swe7</Charset>
     </collation>
-    <collation id="85" parent="1" name="swe7_swedish_ci">
-      <Charset>swe7</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="86" parent="1" name="tis620_bin">
-      <Charset>tis620</Charset>
-    </collation>
-    <collation id="87" parent="1" name="tis620_thai_ci">
+    <collation id="86" parent="1" name="tis620_thai_ci">
       <Charset>tis620</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="88" parent="1" name="ucs2_bin">
-      <Charset>ucs2</Charset>
+    <collation id="87" parent="1" name="tis620_bin">
+      <Charset>tis620</Charset>
     </collation>
-    <collation id="89" parent="1" name="ucs2_croatian_ci">
-      <Charset>ucs2</Charset>
-    </collation>
-    <collation id="90" parent="1" name="ucs2_czech_ci">
-      <Charset>ucs2</Charset>
-    </collation>
-    <collation id="91" parent="1" name="ucs2_danish_ci">
-      <Charset>ucs2</Charset>
-    </collation>
-    <collation id="92" parent="1" name="ucs2_esperanto_ci">
-      <Charset>ucs2</Charset>
-    </collation>
-    <collation id="93" parent="1" name="ucs2_estonian_ci">
-      <Charset>ucs2</Charset>
-    </collation>
-    <collation id="94" parent="1" name="ucs2_general_ci">
+    <collation id="88" parent="1" name="ucs2_general_ci">
       <Charset>ucs2</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="95" parent="1" name="ucs2_general_mysql500_ci">
+    <collation id="89" parent="1" name="ucs2_bin">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="96" parent="1" name="ucs2_german2_ci">
+    <collation id="90" parent="1" name="ucs2_unicode_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="97" parent="1" name="ucs2_hungarian_ci">
+    <collation id="91" parent="1" name="ucs2_icelandic_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="98" parent="1" name="ucs2_icelandic_ci">
+    <collation id="92" parent="1" name="ucs2_latvian_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="99" parent="1" name="ucs2_latvian_ci">
+    <collation id="93" parent="1" name="ucs2_romanian_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="100" parent="1" name="ucs2_lithuanian_ci">
+    <collation id="94" parent="1" name="ucs2_slovenian_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="101" parent="1" name="ucs2_persian_ci">
+    <collation id="95" parent="1" name="ucs2_polish_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="102" parent="1" name="ucs2_polish_ci">
+    <collation id="96" parent="1" name="ucs2_estonian_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="103" parent="1" name="ucs2_roman_ci">
+    <collation id="97" parent="1" name="ucs2_spanish_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="104" parent="1" name="ucs2_romanian_ci">
+    <collation id="98" parent="1" name="ucs2_swedish_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="105" parent="1" name="ucs2_sinhala_ci">
+    <collation id="99" parent="1" name="ucs2_turkish_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="106" parent="1" name="ucs2_slovak_ci">
+    <collation id="100" parent="1" name="ucs2_czech_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="107" parent="1" name="ucs2_slovenian_ci">
+    <collation id="101" parent="1" name="ucs2_danish_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="108" parent="1" name="ucs2_spanish2_ci">
+    <collation id="102" parent="1" name="ucs2_lithuanian_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="109" parent="1" name="ucs2_spanish_ci">
+    <collation id="103" parent="1" name="ucs2_slovak_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="110" parent="1" name="ucs2_swedish_ci">
+    <collation id="104" parent="1" name="ucs2_spanish2_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="111" parent="1" name="ucs2_turkish_ci">
+    <collation id="105" parent="1" name="ucs2_roman_ci">
+      <Charset>ucs2</Charset>
+    </collation>
+    <collation id="106" parent="1" name="ucs2_persian_ci">
+      <Charset>ucs2</Charset>
+    </collation>
+    <collation id="107" parent="1" name="ucs2_esperanto_ci">
+      <Charset>ucs2</Charset>
+    </collation>
+    <collation id="108" parent="1" name="ucs2_hungarian_ci">
+      <Charset>ucs2</Charset>
+    </collation>
+    <collation id="109" parent="1" name="ucs2_sinhala_ci">
+      <Charset>ucs2</Charset>
+    </collation>
+    <collation id="110" parent="1" name="ucs2_german2_ci">
+      <Charset>ucs2</Charset>
+    </collation>
+    <collation id="111" parent="1" name="ucs2_croatian_ci">
       <Charset>ucs2</Charset>
     </collation>
     <collation id="112" parent="1" name="ucs2_unicode_520_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="113" parent="1" name="ucs2_unicode_ci">
+    <collation id="113" parent="1" name="ucs2_vietnamese_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="114" parent="1" name="ucs2_vietnamese_ci">
+    <collation id="114" parent="1" name="ucs2_general_mysql500_ci">
       <Charset>ucs2</Charset>
     </collation>
-    <collation id="115" parent="1" name="ujis_bin">
-      <Charset>ujis</Charset>
-    </collation>
-    <collation id="116" parent="1" name="ujis_japanese_ci">
+    <collation id="115" parent="1" name="ujis_japanese_ci">
       <Charset>ujis</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="117" parent="1" name="utf16_bin">
-      <Charset>utf16</Charset>
+    <collation id="116" parent="1" name="ujis_bin">
+      <Charset>ujis</Charset>
     </collation>
-    <collation id="118" parent="1" name="utf16_croatian_ci">
-      <Charset>utf16</Charset>
-    </collation>
-    <collation id="119" parent="1" name="utf16_czech_ci">
-      <Charset>utf16</Charset>
-    </collation>
-    <collation id="120" parent="1" name="utf16_danish_ci">
-      <Charset>utf16</Charset>
-    </collation>
-    <collation id="121" parent="1" name="utf16_esperanto_ci">
-      <Charset>utf16</Charset>
-    </collation>
-    <collation id="122" parent="1" name="utf16_estonian_ci">
-      <Charset>utf16</Charset>
-    </collation>
-    <collation id="123" parent="1" name="utf16_general_ci">
+    <collation id="117" parent="1" name="utf16_general_ci">
       <Charset>utf16</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="124" parent="1" name="utf16_german2_ci">
+    <collation id="118" parent="1" name="utf16_bin">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="125" parent="1" name="utf16_hungarian_ci">
+    <collation id="119" parent="1" name="utf16_unicode_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="126" parent="1" name="utf16_icelandic_ci">
+    <collation id="120" parent="1" name="utf16_icelandic_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="127" parent="1" name="utf16_latvian_ci">
+    <collation id="121" parent="1" name="utf16_latvian_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="128" parent="1" name="utf16_lithuanian_ci">
+    <collation id="122" parent="1" name="utf16_romanian_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="129" parent="1" name="utf16_persian_ci">
+    <collation id="123" parent="1" name="utf16_slovenian_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="130" parent="1" name="utf16_polish_ci">
+    <collation id="124" parent="1" name="utf16_polish_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="131" parent="1" name="utf16_roman_ci">
+    <collation id="125" parent="1" name="utf16_estonian_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="132" parent="1" name="utf16_romanian_ci">
+    <collation id="126" parent="1" name="utf16_spanish_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="133" parent="1" name="utf16_sinhala_ci">
+    <collation id="127" parent="1" name="utf16_swedish_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="134" parent="1" name="utf16_slovak_ci">
+    <collation id="128" parent="1" name="utf16_turkish_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="135" parent="1" name="utf16_slovenian_ci">
+    <collation id="129" parent="1" name="utf16_czech_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="136" parent="1" name="utf16_spanish2_ci">
+    <collation id="130" parent="1" name="utf16_danish_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="137" parent="1" name="utf16_spanish_ci">
+    <collation id="131" parent="1" name="utf16_lithuanian_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="138" parent="1" name="utf16_swedish_ci">
+    <collation id="132" parent="1" name="utf16_slovak_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="139" parent="1" name="utf16_turkish_ci">
+    <collation id="133" parent="1" name="utf16_spanish2_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="140" parent="1" name="utf16_unicode_520_ci">
+    <collation id="134" parent="1" name="utf16_roman_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="141" parent="1" name="utf16_unicode_ci">
+    <collation id="135" parent="1" name="utf16_persian_ci">
+      <Charset>utf16</Charset>
+    </collation>
+    <collation id="136" parent="1" name="utf16_esperanto_ci">
+      <Charset>utf16</Charset>
+    </collation>
+    <collation id="137" parent="1" name="utf16_hungarian_ci">
+      <Charset>utf16</Charset>
+    </collation>
+    <collation id="138" parent="1" name="utf16_sinhala_ci">
+      <Charset>utf16</Charset>
+    </collation>
+    <collation id="139" parent="1" name="utf16_german2_ci">
+      <Charset>utf16</Charset>
+    </collation>
+    <collation id="140" parent="1" name="utf16_croatian_ci">
+      <Charset>utf16</Charset>
+    </collation>
+    <collation id="141" parent="1" name="utf16_unicode_520_ci">
       <Charset>utf16</Charset>
     </collation>
     <collation id="142" parent="1" name="utf16_vietnamese_ci">
       <Charset>utf16</Charset>
     </collation>
-    <collation id="143" parent="1" name="utf16le_bin">
-      <Charset>utf16le</Charset>
-    </collation>
-    <collation id="144" parent="1" name="utf16le_general_ci">
+    <collation id="143" parent="1" name="utf16le_general_ci">
       <Charset>utf16le</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="145" parent="1" name="utf32_bin">
-      <Charset>utf32</Charset>
+    <collation id="144" parent="1" name="utf16le_bin">
+      <Charset>utf16le</Charset>
     </collation>
-    <collation id="146" parent="1" name="utf32_croatian_ci">
-      <Charset>utf32</Charset>
-    </collation>
-    <collation id="147" parent="1" name="utf32_czech_ci">
-      <Charset>utf32</Charset>
-    </collation>
-    <collation id="148" parent="1" name="utf32_danish_ci">
-      <Charset>utf32</Charset>
-    </collation>
-    <collation id="149" parent="1" name="utf32_esperanto_ci">
-      <Charset>utf32</Charset>
-    </collation>
-    <collation id="150" parent="1" name="utf32_estonian_ci">
-      <Charset>utf32</Charset>
-    </collation>
-    <collation id="151" parent="1" name="utf32_general_ci">
+    <collation id="145" parent="1" name="utf32_general_ci">
       <Charset>utf32</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="152" parent="1" name="utf32_german2_ci">
+    <collation id="146" parent="1" name="utf32_bin">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="153" parent="1" name="utf32_hungarian_ci">
+    <collation id="147" parent="1" name="utf32_unicode_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="154" parent="1" name="utf32_icelandic_ci">
+    <collation id="148" parent="1" name="utf32_icelandic_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="155" parent="1" name="utf32_latvian_ci">
+    <collation id="149" parent="1" name="utf32_latvian_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="156" parent="1" name="utf32_lithuanian_ci">
+    <collation id="150" parent="1" name="utf32_romanian_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="157" parent="1" name="utf32_persian_ci">
+    <collation id="151" parent="1" name="utf32_slovenian_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="158" parent="1" name="utf32_polish_ci">
+    <collation id="152" parent="1" name="utf32_polish_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="159" parent="1" name="utf32_roman_ci">
+    <collation id="153" parent="1" name="utf32_estonian_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="160" parent="1" name="utf32_romanian_ci">
+    <collation id="154" parent="1" name="utf32_spanish_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="161" parent="1" name="utf32_sinhala_ci">
+    <collation id="155" parent="1" name="utf32_swedish_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="162" parent="1" name="utf32_slovak_ci">
+    <collation id="156" parent="1" name="utf32_turkish_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="163" parent="1" name="utf32_slovenian_ci">
+    <collation id="157" parent="1" name="utf32_czech_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="164" parent="1" name="utf32_spanish2_ci">
+    <collation id="158" parent="1" name="utf32_danish_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="165" parent="1" name="utf32_spanish_ci">
+    <collation id="159" parent="1" name="utf32_lithuanian_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="166" parent="1" name="utf32_swedish_ci">
+    <collation id="160" parent="1" name="utf32_slovak_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="167" parent="1" name="utf32_turkish_ci">
+    <collation id="161" parent="1" name="utf32_spanish2_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="168" parent="1" name="utf32_unicode_520_ci">
+    <collation id="162" parent="1" name="utf32_roman_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="169" parent="1" name="utf32_unicode_ci">
+    <collation id="163" parent="1" name="utf32_persian_ci">
+      <Charset>utf32</Charset>
+    </collation>
+    <collation id="164" parent="1" name="utf32_esperanto_ci">
+      <Charset>utf32</Charset>
+    </collation>
+    <collation id="165" parent="1" name="utf32_hungarian_ci">
+      <Charset>utf32</Charset>
+    </collation>
+    <collation id="166" parent="1" name="utf32_sinhala_ci">
+      <Charset>utf32</Charset>
+    </collation>
+    <collation id="167" parent="1" name="utf32_german2_ci">
+      <Charset>utf32</Charset>
+    </collation>
+    <collation id="168" parent="1" name="utf32_croatian_ci">
+      <Charset>utf32</Charset>
+    </collation>
+    <collation id="169" parent="1" name="utf32_unicode_520_ci">
       <Charset>utf32</Charset>
     </collation>
     <collation id="170" parent="1" name="utf32_vietnamese_ci">
       <Charset>utf32</Charset>
     </collation>
-    <collation id="171" parent="1" name="utf8mb3_bin">
-      <Charset>utf8mb3</Charset>
-    </collation>
-    <collation id="172" parent="1" name="utf8mb3_croatian_ci">
-      <Charset>utf8mb3</Charset>
-    </collation>
-    <collation id="173" parent="1" name="utf8mb3_czech_ci">
-      <Charset>utf8mb3</Charset>
-    </collation>
-    <collation id="174" parent="1" name="utf8mb3_danish_ci">
-      <Charset>utf8mb3</Charset>
-    </collation>
-    <collation id="175" parent="1" name="utf8mb3_esperanto_ci">
-      <Charset>utf8mb3</Charset>
-    </collation>
-    <collation id="176" parent="1" name="utf8mb3_estonian_ci">
-      <Charset>utf8mb3</Charset>
-    </collation>
-    <collation id="177" parent="1" name="utf8mb3_general_ci">
+    <collation id="171" parent="1" name="utf8mb3_general_ci">
       <Charset>utf8mb3</Charset>
       <DefaultForCharset>1</DefaultForCharset>
     </collation>
-    <collation id="178" parent="1" name="utf8mb3_general_mysql500_ci">
+    <collation id="172" parent="1" name="utf8mb3_tolower_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="179" parent="1" name="utf8mb3_german2_ci">
+    <collation id="173" parent="1" name="utf8mb3_bin">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="180" parent="1" name="utf8mb3_hungarian_ci">
+    <collation id="174" parent="1" name="utf8mb3_unicode_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="181" parent="1" name="utf8mb3_icelandic_ci">
+    <collation id="175" parent="1" name="utf8mb3_icelandic_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="182" parent="1" name="utf8mb3_latvian_ci">
+    <collation id="176" parent="1" name="utf8mb3_latvian_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="183" parent="1" name="utf8mb3_lithuanian_ci">
+    <collation id="177" parent="1" name="utf8mb3_romanian_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="184" parent="1" name="utf8mb3_persian_ci">
+    <collation id="178" parent="1" name="utf8mb3_slovenian_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="185" parent="1" name="utf8mb3_polish_ci">
+    <collation id="179" parent="1" name="utf8mb3_polish_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="186" parent="1" name="utf8mb3_roman_ci">
+    <collation id="180" parent="1" name="utf8mb3_estonian_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="187" parent="1" name="utf8mb3_romanian_ci">
+    <collation id="181" parent="1" name="utf8mb3_spanish_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="188" parent="1" name="utf8mb3_sinhala_ci">
+    <collation id="182" parent="1" name="utf8mb3_swedish_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="189" parent="1" name="utf8mb3_slovak_ci">
+    <collation id="183" parent="1" name="utf8mb3_turkish_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="190" parent="1" name="utf8mb3_slovenian_ci">
+    <collation id="184" parent="1" name="utf8mb3_czech_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="191" parent="1" name="utf8mb3_spanish2_ci">
+    <collation id="185" parent="1" name="utf8mb3_danish_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="192" parent="1" name="utf8mb3_spanish_ci">
+    <collation id="186" parent="1" name="utf8mb3_lithuanian_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="193" parent="1" name="utf8mb3_swedish_ci">
+    <collation id="187" parent="1" name="utf8mb3_slovak_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="194" parent="1" name="utf8mb3_tolower_ci">
+    <collation id="188" parent="1" name="utf8mb3_spanish2_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="195" parent="1" name="utf8mb3_turkish_ci">
+    <collation id="189" parent="1" name="utf8mb3_roman_ci">
+      <Charset>utf8mb3</Charset>
+    </collation>
+    <collation id="190" parent="1" name="utf8mb3_persian_ci">
+      <Charset>utf8mb3</Charset>
+    </collation>
+    <collation id="191" parent="1" name="utf8mb3_esperanto_ci">
+      <Charset>utf8mb3</Charset>
+    </collation>
+    <collation id="192" parent="1" name="utf8mb3_hungarian_ci">
+      <Charset>utf8mb3</Charset>
+    </collation>
+    <collation id="193" parent="1" name="utf8mb3_sinhala_ci">
+      <Charset>utf8mb3</Charset>
+    </collation>
+    <collation id="194" parent="1" name="utf8mb3_german2_ci">
+      <Charset>utf8mb3</Charset>
+    </collation>
+    <collation id="195" parent="1" name="utf8mb3_croatian_ci">
       <Charset>utf8mb3</Charset>
     </collation>
     <collation id="196" parent="1" name="utf8mb3_unicode_520_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="197" parent="1" name="utf8mb3_unicode_ci">
+    <collation id="197" parent="1" name="utf8mb3_vietnamese_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="198" parent="1" name="utf8mb3_vietnamese_ci">
+    <collation id="198" parent="1" name="utf8mb3_general_mysql500_ci">
       <Charset>utf8mb3</Charset>
     </collation>
-    <collation id="199" parent="1" name="utf8mb4_0900_ai_ci">
-      <Charset>utf8mb4</Charset>
-      <DefaultForCharset>1</DefaultForCharset>
-    </collation>
-    <collation id="200" parent="1" name="utf8mb4_0900_as_ci">
+    <collation id="199" parent="1" name="utf8mb4_general_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="201" parent="1" name="utf8mb4_0900_as_cs">
+    <collation id="200" parent="1" name="utf8mb4_bin">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="202" parent="1" name="utf8mb4_0900_bin">
+    <collation id="201" parent="1" name="utf8mb4_unicode_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="203" parent="1" name="utf8mb4_bg_0900_ai_ci">
+    <collation id="202" parent="1" name="utf8mb4_icelandic_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="204" parent="1" name="utf8mb4_bg_0900_as_cs">
+    <collation id="203" parent="1" name="utf8mb4_latvian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="205" parent="1" name="utf8mb4_bin">
+    <collation id="204" parent="1" name="utf8mb4_romanian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="206" parent="1" name="utf8mb4_bs_0900_ai_ci">
+    <collation id="205" parent="1" name="utf8mb4_slovenian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="207" parent="1" name="utf8mb4_bs_0900_as_cs">
+    <collation id="206" parent="1" name="utf8mb4_polish_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="208" parent="1" name="utf8mb4_croatian_ci">
+    <collation id="207" parent="1" name="utf8mb4_estonian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="209" parent="1" name="utf8mb4_cs_0900_ai_ci">
+    <collation id="208" parent="1" name="utf8mb4_spanish_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="210" parent="1" name="utf8mb4_cs_0900_as_cs">
+    <collation id="209" parent="1" name="utf8mb4_swedish_ci">
+      <Charset>utf8mb4</Charset>
+    </collation>
+    <collation id="210" parent="1" name="utf8mb4_turkish_ci">
       <Charset>utf8mb4</Charset>
     </collation>
     <collation id="211" parent="1" name="utf8mb4_czech_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="212" parent="1" name="utf8mb4_da_0900_ai_ci">
+    <collation id="212" parent="1" name="utf8mb4_danish_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="213" parent="1" name="utf8mb4_da_0900_as_cs">
+    <collation id="213" parent="1" name="utf8mb4_lithuanian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="214" parent="1" name="utf8mb4_danish_ci">
+    <collation id="214" parent="1" name="utf8mb4_slovak_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="215" parent="1" name="utf8mb4_de_pb_0900_ai_ci">
+    <collation id="215" parent="1" name="utf8mb4_spanish2_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="216" parent="1" name="utf8mb4_de_pb_0900_as_cs">
+    <collation id="216" parent="1" name="utf8mb4_roman_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="217" parent="1" name="utf8mb4_eo_0900_ai_ci">
+    <collation id="217" parent="1" name="utf8mb4_persian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="218" parent="1" name="utf8mb4_eo_0900_as_cs">
+    <collation id="218" parent="1" name="utf8mb4_esperanto_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="219" parent="1" name="utf8mb4_es_0900_ai_ci">
+    <collation id="219" parent="1" name="utf8mb4_hungarian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="220" parent="1" name="utf8mb4_es_0900_as_cs">
+    <collation id="220" parent="1" name="utf8mb4_sinhala_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="221" parent="1" name="utf8mb4_es_trad_0900_ai_ci">
+    <collation id="221" parent="1" name="utf8mb4_german2_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="222" parent="1" name="utf8mb4_es_trad_0900_as_cs">
+    <collation id="222" parent="1" name="utf8mb4_croatian_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="223" parent="1" name="utf8mb4_esperanto_ci">
+    <collation id="223" parent="1" name="utf8mb4_unicode_520_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="224" parent="1" name="utf8mb4_estonian_ci">
+    <collation id="224" parent="1" name="utf8mb4_vietnamese_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="225" parent="1" name="utf8mb4_et_0900_ai_ci">
+    <collation id="225" parent="1" name="utf8mb4_0900_ai_ci">
+      <Charset>utf8mb4</Charset>
+      <DefaultForCharset>1</DefaultForCharset>
+    </collation>
+    <collation id="226" parent="1" name="utf8mb4_de_pb_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="226" parent="1" name="utf8mb4_et_0900_as_cs">
+    <collation id="227" parent="1" name="utf8mb4_is_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="227" parent="1" name="utf8mb4_general_ci">
+    <collation id="228" parent="1" name="utf8mb4_lv_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="228" parent="1" name="utf8mb4_german2_ci">
+    <collation id="229" parent="1" name="utf8mb4_ro_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="229" parent="1" name="utf8mb4_gl_0900_ai_ci">
+    <collation id="230" parent="1" name="utf8mb4_sl_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="230" parent="1" name="utf8mb4_gl_0900_as_cs">
+    <collation id="231" parent="1" name="utf8mb4_pl_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="231" parent="1" name="utf8mb4_hr_0900_ai_ci">
+    <collation id="232" parent="1" name="utf8mb4_et_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="232" parent="1" name="utf8mb4_hr_0900_as_cs">
+    <collation id="233" parent="1" name="utf8mb4_es_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="233" parent="1" name="utf8mb4_hu_0900_ai_ci">
+    <collation id="234" parent="1" name="utf8mb4_sv_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="234" parent="1" name="utf8mb4_hu_0900_as_cs">
+    <collation id="235" parent="1" name="utf8mb4_tr_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="235" parent="1" name="utf8mb4_hungarian_ci">
+    <collation id="236" parent="1" name="utf8mb4_cs_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="236" parent="1" name="utf8mb4_icelandic_ci">
+    <collation id="237" parent="1" name="utf8mb4_da_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="237" parent="1" name="utf8mb4_is_0900_ai_ci">
+    <collation id="238" parent="1" name="utf8mb4_lt_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="238" parent="1" name="utf8mb4_is_0900_as_cs">
+    <collation id="239" parent="1" name="utf8mb4_sk_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="239" parent="1" name="utf8mb4_ja_0900_as_cs">
-      <Charset>utf8mb4</Charset>
-    </collation>
-    <collation id="240" parent="1" name="utf8mb4_ja_0900_as_cs_ks">
+    <collation id="240" parent="1" name="utf8mb4_es_trad_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
     <collation id="241" parent="1" name="utf8mb4_la_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="242" parent="1" name="utf8mb4_la_0900_as_cs">
+    <collation id="242" parent="1" name="utf8mb4_eo_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="243" parent="1" name="utf8mb4_latvian_ci">
+    <collation id="243" parent="1" name="utf8mb4_hu_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="244" parent="1" name="utf8mb4_lithuanian_ci">
+    <collation id="244" parent="1" name="utf8mb4_hr_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="245" parent="1" name="utf8mb4_lt_0900_ai_ci">
+    <collation id="245" parent="1" name="utf8mb4_vi_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="246" parent="1" name="utf8mb4_lt_0900_as_cs">
+    <collation id="246" parent="1" name="utf8mb4_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="247" parent="1" name="utf8mb4_lv_0900_ai_ci">
+    <collation id="247" parent="1" name="utf8mb4_de_pb_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="248" parent="1" name="utf8mb4_lv_0900_as_cs">
+    <collation id="248" parent="1" name="utf8mb4_is_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="249" parent="1" name="utf8mb4_mn_cyrl_0900_ai_ci">
+    <collation id="249" parent="1" name="utf8mb4_lv_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="250" parent="1" name="utf8mb4_mn_cyrl_0900_as_cs">
+    <collation id="250" parent="1" name="utf8mb4_ro_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="251" parent="1" name="utf8mb4_nb_0900_ai_ci">
+    <collation id="251" parent="1" name="utf8mb4_sl_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="252" parent="1" name="utf8mb4_nb_0900_as_cs">
+    <collation id="252" parent="1" name="utf8mb4_pl_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="253" parent="1" name="utf8mb4_nn_0900_ai_ci">
+    <collation id="253" parent="1" name="utf8mb4_et_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="254" parent="1" name="utf8mb4_nn_0900_as_cs">
+    <collation id="254" parent="1" name="utf8mb4_es_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="255" parent="1" name="utf8mb4_persian_ci">
+    <collation id="255" parent="1" name="utf8mb4_sv_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="256" parent="1" name="utf8mb4_pl_0900_ai_ci">
+    <collation id="256" parent="1" name="utf8mb4_tr_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="257" parent="1" name="utf8mb4_pl_0900_as_cs">
+    <collation id="257" parent="1" name="utf8mb4_cs_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="258" parent="1" name="utf8mb4_polish_ci">
+    <collation id="258" parent="1" name="utf8mb4_da_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="259" parent="1" name="utf8mb4_ro_0900_ai_ci">
+    <collation id="259" parent="1" name="utf8mb4_lt_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="260" parent="1" name="utf8mb4_ro_0900_as_cs">
+    <collation id="260" parent="1" name="utf8mb4_sk_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="261" parent="1" name="utf8mb4_roman_ci">
+    <collation id="261" parent="1" name="utf8mb4_es_trad_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="262" parent="1" name="utf8mb4_romanian_ci">
+    <collation id="262" parent="1" name="utf8mb4_la_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="263" parent="1" name="utf8mb4_ru_0900_ai_ci">
+    <collation id="263" parent="1" name="utf8mb4_eo_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="264" parent="1" name="utf8mb4_ru_0900_as_cs">
+    <collation id="264" parent="1" name="utf8mb4_hu_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="265" parent="1" name="utf8mb4_sinhala_ci">
+    <collation id="265" parent="1" name="utf8mb4_hr_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="266" parent="1" name="utf8mb4_sk_0900_ai_ci">
+    <collation id="266" parent="1" name="utf8mb4_vi_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="267" parent="1" name="utf8mb4_sk_0900_as_cs">
+    <collation id="267" parent="1" name="utf8mb4_ja_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="268" parent="1" name="utf8mb4_sl_0900_ai_ci">
+    <collation id="268" parent="1" name="utf8mb4_ja_0900_as_cs_ks">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="269" parent="1" name="utf8mb4_sl_0900_as_cs">
+    <collation id="269" parent="1" name="utf8mb4_0900_as_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="270" parent="1" name="utf8mb4_slovak_ci">
+    <collation id="270" parent="1" name="utf8mb4_ru_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="271" parent="1" name="utf8mb4_slovenian_ci">
+    <collation id="271" parent="1" name="utf8mb4_ru_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="272" parent="1" name="utf8mb4_spanish2_ci">
+    <collation id="272" parent="1" name="utf8mb4_zh_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="273" parent="1" name="utf8mb4_spanish_ci">
+    <collation id="273" parent="1" name="utf8mb4_0900_bin">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="274" parent="1" name="utf8mb4_sr_latn_0900_ai_ci">
+    <collation id="274" parent="1" name="utf8mb4_nb_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="275" parent="1" name="utf8mb4_sr_latn_0900_as_cs">
+    <collation id="275" parent="1" name="utf8mb4_nb_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="276" parent="1" name="utf8mb4_sv_0900_ai_ci">
+    <collation id="276" parent="1" name="utf8mb4_nn_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="277" parent="1" name="utf8mb4_sv_0900_as_cs">
+    <collation id="277" parent="1" name="utf8mb4_nn_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="278" parent="1" name="utf8mb4_swedish_ci">
+    <collation id="278" parent="1" name="utf8mb4_sr_latn_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="279" parent="1" name="utf8mb4_tr_0900_ai_ci">
+    <collation id="279" parent="1" name="utf8mb4_sr_latn_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="280" parent="1" name="utf8mb4_tr_0900_as_cs">
+    <collation id="280" parent="1" name="utf8mb4_bs_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="281" parent="1" name="utf8mb4_turkish_ci">
+    <collation id="281" parent="1" name="utf8mb4_bs_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="282" parent="1" name="utf8mb4_unicode_520_ci">
+    <collation id="282" parent="1" name="utf8mb4_bg_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="283" parent="1" name="utf8mb4_unicode_ci">
+    <collation id="283" parent="1" name="utf8mb4_bg_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="284" parent="1" name="utf8mb4_vi_0900_ai_ci">
+    <collation id="284" parent="1" name="utf8mb4_gl_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="285" parent="1" name="utf8mb4_vi_0900_as_cs">
+    <collation id="285" parent="1" name="utf8mb4_gl_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="286" parent="1" name="utf8mb4_vietnamese_ci">
+    <collation id="286" parent="1" name="utf8mb4_mn_cyrl_0900_ai_ci">
       <Charset>utf8mb4</Charset>
     </collation>
-    <collation id="287" parent="1" name="utf8mb4_zh_0900_as_cs">
+    <collation id="287" parent="1" name="utf8mb4_mn_cyrl_0900_as_cs">
       <Charset>utf8mb4</Charset>
     </collation>
-    <schema id="288" parent="1" name="Koco">
-      <LastIntrospectionLocalTimestamp>2025-04-29.16:02:50</LastIntrospectionLocalTimestamp>
+    <schema id="288" parent="1" name="mysql">
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </schema>
     <schema id="289" parent="1" name="information_schema">
       <CollationName>utf8mb3_general_ci</CollationName>
     </schema>
-    <schema id="290" parent="1" name="ktb_db">
+    <schema id="290" parent="1" name="performance_schema">
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </schema>
-    <schema id="291" parent="1" name="mysql">
+    <schema id="291" parent="1" name="sys">
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </schema>
-    <schema id="292" parent="1" name="performance_schema">
+    <schema id="292" parent="1" name="ktb_db">
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </schema>
-    <schema id="293" parent="1" name="sys">
+    <schema id="293" parent="1" name="Koco">
+      <LastIntrospectionLocalTimestamp>2025-04-29.16:02:50</LastIntrospectionLocalTimestamp>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </schema>
     <user id="294" parent="1" name="mysql.infoschema">
@@ -1037,55 +1037,55 @@ sys|schema||mysql.sys|localhost|TRIGGER|G</Grants>
       <Host>localhost</Host>
       <Plugin>caching_sha2_password</Plugin>
     </user>
-    <table id="298" parent="288" name="category">
+    <table id="298" parent="293" name="category">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="299" parent="288" name="cluster">
+    <table id="299" parent="293" name="cluster">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="300" parent="288" name="oauth">
+    <table id="300" parent="293" name="oauth">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="301" parent="288" name="problem">
+    <table id="301" parent="293" name="problem">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="302" parent="288" name="problem_category">
+    <table id="302" parent="293" name="problem_category">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="303" parent="288" name="problem_set">
+    <table id="303" parent="293" name="problem_set">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="304" parent="288" name="problem_set_problem">
+    <table id="304" parent="293" name="problem_set_problem">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="305" parent="288" name="problem_set_solution">
+    <table id="305" parent="293" name="problem_set_solution">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="306" parent="288" name="solution">
+    <table id="306" parent="293" name="solution">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="307" parent="288" name="survey">
+    <table id="307" parent="293" name="survey">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="308" parent="288" name="user_algorithm_stats">
+    <table id="308" parent="293" name="user_algorithm_stats">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="309" parent="288" name="user_detail">
+    <table id="309" parent="293" name="user_detail">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
-    <table id="310" parent="288" name="users">
+    <table id="310" parent="293" name="users">
       <Engine>InnoDB</Engine>
       <CollationName>utf8mb4_0900_ai_ci</CollationName>
     </table>
@@ -1464,324 +1464,334 @@ sys|schema||mysql.sys|localhost|TRIGGER|G</Grants>
       <Position>5</Position>
       <StoredType>datetime(6)|0s</StoredType>
     </column>
-    <column id="385" parent="306" name="explanation">
+    <column id="385" parent="306" name="problem_id">
       <NotNull>1</NotNull>
       <Position>6</Position>
-      <StoredType>text|0s</StoredType>
-    </column>
-    <column id="386" parent="306" name="problem_id">
-      <NotNull>1</NotNull>
-      <Position>7</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <foreign-key id="387" parent="306" name="FKrbtm4ry2my317kdkkixgjrts3">
+    <column id="386" parent="306" name="algorithm">
+      <NotNull>1</NotNull>
+      <Position>7</Position>
+      <StoredType>text|0s</StoredType>
+    </column>
+    <column id="387" parent="306" name="problem_description">
+      <NotNull>1</NotNull>
+      <Position>8</Position>
+      <StoredType>text|0s</StoredType>
+    </column>
+    <column id="388" parent="306" name="problem_solving">
+      <NotNull>1</NotNull>
+      <Position>9</Position>
+      <StoredType>text|0s</StoredType>
+    </column>
+    <foreign-key id="389" parent="306" name="FKrbtm4ry2my317kdkkixgjrts3">
       <ColNames>problem_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>problem</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <index id="388" parent="306" name="PRIMARY">
+    <index id="390" parent="306" name="PRIMARY">
       <ColNames>id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <index id="389" parent="306" name="UKhpmodbcipntwj2icmhsgy90u8">
+    <index id="391" parent="306" name="UKhpmodbcipntwj2icmhsgy90u8">
       <ColNames>problem_id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <key id="390" parent="306" name="PRIMARY">
+    <key id="392" parent="306" name="PRIMARY">
       <NameSurrogate>1</NameSurrogate>
       <Primary>1</Primary>
       <UnderlyingIndexName>PRIMARY</UnderlyingIndexName>
     </key>
-    <key id="391" parent="306" name="UKhpmodbcipntwj2icmhsgy90u8">
+    <key id="393" parent="306" name="UKhpmodbcipntwj2icmhsgy90u8">
       <UnderlyingIndexName>UKhpmodbcipntwj2icmhsgy90u8</UnderlyingIndexName>
     </key>
-    <column id="392" parent="307" name="id">
+    <column id="394" parent="307" name="id">
       <AutoIncrement>1</AutoIncrement>
       <NotNull>1</NotNull>
       <Position>1</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="393" parent="307" name="answered_at">
+    <column id="395" parent="307" name="answered_at">
       <NotNull>1</NotNull>
       <Position>2</Position>
       <StoredType>datetime(6)|0s</StoredType>
     </column>
-    <column id="394" parent="307" name="difficulty_level">
+    <column id="396" parent="307" name="difficulty_level">
       <NotNull>1</NotNull>
       <Position>3</Position>
       <StoredType>enum(&apos;EASY&apos;, &apos;HARD&apos;, &apos;MEDIUM&apos;)|0e</StoredType>
     </column>
-    <column id="395" parent="307" name="is_solved">
+    <column id="397" parent="307" name="is_solved">
       <NotNull>1</NotNull>
       <Position>4</Position>
       <StoredType>bit(1)|0s</StoredType>
     </column>
-    <column id="396" parent="307" name="problem_id">
+    <column id="398" parent="307" name="problem_id">
       <NotNull>1</NotNull>
       <Position>5</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="397" parent="307" name="problem_set_id">
+    <column id="399" parent="307" name="problem_set_id">
       <NotNull>1</NotNull>
       <Position>6</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="398" parent="307" name="user_id">
+    <column id="400" parent="307" name="user_id">
       <NotNull>1</NotNull>
       <Position>7</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <foreign-key id="399" parent="307" name="FKpx0j1wqw5j3dvdmx3279ksvl1">
+    <foreign-key id="401" parent="307" name="FKpx0j1wqw5j3dvdmx3279ksvl1">
       <ColNames>problem_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>problem</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <foreign-key id="400" parent="307" name="FK5nhm3d6b0v7dsipilp9iyy80g">
+    <foreign-key id="402" parent="307" name="FK5nhm3d6b0v7dsipilp9iyy80g">
       <ColNames>problem_set_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>problem_set</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <foreign-key id="401" parent="307" name="FK92gyhe01cej7nwm64taxcka2k">
+    <foreign-key id="403" parent="307" name="FK92gyhe01cej7nwm64taxcka2k">
       <ColNames>user_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>users</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <index id="402" parent="307" name="PRIMARY">
+    <index id="404" parent="307" name="PRIMARY">
       <ColNames>id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <index id="403" parent="307" name="uq_user_problemset_problem">
+    <index id="405" parent="307" name="uq_user_problemset_problem">
       <ColNames>user_id
 problem_set_id
 problem_id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <index id="404" parent="307" name="FKpx0j1wqw5j3dvdmx3279ksvl1">
+    <index id="406" parent="307" name="FKpx0j1wqw5j3dvdmx3279ksvl1">
       <ColNames>problem_id</ColNames>
       <Type>btree</Type>
     </index>
-    <index id="405" parent="307" name="FK5nhm3d6b0v7dsipilp9iyy80g">
+    <index id="407" parent="307" name="FK5nhm3d6b0v7dsipilp9iyy80g">
       <ColNames>problem_set_id</ColNames>
       <Type>btree</Type>
     </index>
-    <key id="406" parent="307" name="PRIMARY">
+    <key id="408" parent="307" name="PRIMARY">
       <NameSurrogate>1</NameSurrogate>
       <Primary>1</Primary>
       <UnderlyingIndexName>PRIMARY</UnderlyingIndexName>
     </key>
-    <key id="407" parent="307" name="uq_user_problemset_problem">
+    <key id="409" parent="307" name="uq_user_problemset_problem">
       <UnderlyingIndexName>uq_user_problemset_problem</UnderlyingIndexName>
     </key>
-    <column id="408" parent="308" name="id">
+    <column id="410" parent="308" name="id">
       <AutoIncrement>1</AutoIncrement>
       <NotNull>1</NotNull>
       <Position>1</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="409" parent="308" name="correct_rate">
+    <column id="411" parent="308" name="correct_rate">
       <NotNull>1</NotNull>
       <Position>2</Position>
       <StoredType>int|0s</StoredType>
     </column>
-    <column id="410" parent="308" name="category_id">
+    <column id="412" parent="308" name="category_id">
       <NotNull>1</NotNull>
       <Position>3</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="411" parent="308" name="user_id">
+    <column id="413" parent="308" name="user_id">
       <NotNull>1</NotNull>
       <Position>4</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <foreign-key id="412" parent="308" name="FKdq22omykbq170vt1ap5p67as7">
+    <foreign-key id="414" parent="308" name="FKdq22omykbq170vt1ap5p67as7">
       <ColNames>category_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>category</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <foreign-key id="413" parent="308" name="FKftk2tkwdmu7lu4j9gtu6n08q6">
+    <foreign-key id="415" parent="308" name="FKftk2tkwdmu7lu4j9gtu6n08q6">
       <ColNames>user_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>users</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <index id="414" parent="308" name="PRIMARY">
+    <index id="416" parent="308" name="PRIMARY">
       <ColNames>id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <index id="415" parent="308" name="FKdq22omykbq170vt1ap5p67as7">
+    <index id="417" parent="308" name="FKdq22omykbq170vt1ap5p67as7">
       <ColNames>category_id</ColNames>
       <Type>btree</Type>
     </index>
-    <index id="416" parent="308" name="FKftk2tkwdmu7lu4j9gtu6n08q6">
+    <index id="418" parent="308" name="FKftk2tkwdmu7lu4j9gtu6n08q6">
       <ColNames>user_id</ColNames>
       <Type>btree</Type>
     </index>
-    <key id="417" parent="308" name="PRIMARY">
+    <key id="419" parent="308" name="PRIMARY">
       <NameSurrogate>1</NameSurrogate>
       <Primary>1</Primary>
       <UnderlyingIndexName>PRIMARY</UnderlyingIndexName>
     </key>
-    <column id="418" parent="309" name="id">
+    <column id="420" parent="309" name="id">
       <AutoIncrement>1</AutoIncrement>
       <NotNull>1</NotNull>
       <Position>1</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="419" parent="309" name="cluster_time">
+    <column id="421" parent="309" name="cluster_time">
       <NotNull>1</NotNull>
       <Position>2</Position>
       <StoredType>datetime(6)|0s</StoredType>
     </column>
-    <column id="420" parent="309" name="continuous_attendance">
+    <column id="422" parent="309" name="continuous_attendance">
       <NotNull>1</NotNull>
       <Position>3</Position>
       <StoredType>int|0s</StoredType>
     </column>
-    <column id="421" parent="309" name="correct_cnt">
+    <column id="423" parent="309" name="correct_cnt">
       <NotNull>1</NotNull>
       <Position>4</Position>
       <StoredType>int|0s</StoredType>
     </column>
-    <column id="422" parent="309" name="correct_rate">
+    <column id="424" parent="309" name="correct_rate">
       <NotNull>1</NotNull>
       <Position>5</Position>
       <StoredType>decimal(4,1 digit)|0s</StoredType>
     </column>
-    <column id="423" parent="309" name="difficulty_avg">
+    <column id="425" parent="309" name="difficulty_avg">
       <NotNull>1</NotNull>
       <Position>6</Position>
       <StoredType>decimal(4,1 digit)|0s</StoredType>
     </column>
-    <column id="424" parent="309" name="response_rate">
+    <column id="426" parent="309" name="response_rate">
       <NotNull>1</NotNull>
       <Position>7</Position>
       <StoredType>decimal(4,1 digit)|0s</StoredType>
     </column>
-    <column id="425" parent="309" name="survey_cnt">
+    <column id="427" parent="309" name="survey_cnt">
       <NotNull>1</NotNull>
       <Position>8</Position>
       <StoredType>int|0s</StoredType>
     </column>
-    <column id="426" parent="309" name="total_attendance">
+    <column id="428" parent="309" name="total_attendance">
       <NotNull>1</NotNull>
       <Position>9</Position>
       <StoredType>int|0s</StoredType>
     </column>
-    <column id="427" parent="309" name="updated_at">
+    <column id="429" parent="309" name="updated_at">
       <Position>10</Position>
       <StoredType>datetime(6)|0s</StoredType>
     </column>
-    <column id="428" parent="309" name="cluster_id">
+    <column id="430" parent="309" name="cluster_id">
       <NotNull>1</NotNull>
       <Position>11</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="429" parent="309" name="user_id">
+    <column id="431" parent="309" name="user_id">
       <NotNull>1</NotNull>
       <Position>12</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <foreign-key id="430" parent="309" name="FK4t6x4stk7mudyokoti7km9mgi">
+    <foreign-key id="432" parent="309" name="FK4t6x4stk7mudyokoti7km9mgi">
       <ColNames>cluster_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>cluster</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <foreign-key id="431" parent="309" name="FKr6i0t96qgu9l8l5nn2vqo8rcl">
+    <foreign-key id="433" parent="309" name="FKr6i0t96qgu9l8l5nn2vqo8rcl">
       <ColNames>user_id</ColNames>
       <RefColNames>id</RefColNames>
       <RefTableName>users</RefTableName>
       <RefTableParentName>koco</RefTableParentName>
     </foreign-key>
-    <index id="432" parent="309" name="PRIMARY">
+    <index id="434" parent="309" name="PRIMARY">
       <ColNames>id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <index id="433" parent="309" name="UKdm7hrxg9mvrb92v1p3o6wg97u">
+    <index id="435" parent="309" name="UKdm7hrxg9mvrb92v1p3o6wg97u">
       <ColNames>user_id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <index id="434" parent="309" name="FK4t6x4stk7mudyokoti7km9mgi">
+    <index id="436" parent="309" name="FK4t6x4stk7mudyokoti7km9mgi">
       <ColNames>cluster_id</ColNames>
       <Type>btree</Type>
     </index>
-    <key id="435" parent="309" name="PRIMARY">
+    <key id="437" parent="309" name="PRIMARY">
       <NameSurrogate>1</NameSurrogate>
       <Primary>1</Primary>
       <UnderlyingIndexName>PRIMARY</UnderlyingIndexName>
     </key>
-    <key id="436" parent="309" name="UKdm7hrxg9mvrb92v1p3o6wg97u">
+    <key id="438" parent="309" name="UKdm7hrxg9mvrb92v1p3o6wg97u">
       <UnderlyingIndexName>UKdm7hrxg9mvrb92v1p3o6wg97u</UnderlyingIndexName>
     </key>
-    <column id="437" parent="310" name="id">
+    <column id="439" parent="310" name="id">
       <AutoIncrement>1</AutoIncrement>
       <NotNull>1</NotNull>
       <Position>1</Position>
       <StoredType>bigint|0s</StoredType>
     </column>
-    <column id="438" parent="310" name="created_at">
+    <column id="440" parent="310" name="created_at">
       <Position>2</Position>
       <StoredType>datetime(6)|0s</StoredType>
     </column>
-    <column id="439" parent="310" name="deleted_at">
+    <column id="441" parent="310" name="deleted_at">
       <Position>3</Position>
       <StoredType>datetime(6)|0s</StoredType>
     </column>
-    <column id="440" parent="310" name="email">
+    <column id="442" parent="310" name="email">
       <NotNull>1</NotNull>
       <Position>4</Position>
       <StoredType>varchar(255)|0s</StoredType>
     </column>
-    <column id="441" parent="310" name="name">
+    <column id="443" parent="310" name="name">
       <NotNull>1</NotNull>
       <Position>5</Position>
       <StoredType>varchar(10)|0s</StoredType>
     </column>
-    <column id="442" parent="310" name="nickname">
+    <column id="444" parent="310" name="nickname">
       <NotNull>1</NotNull>
       <Position>6</Position>
       <StoredType>varchar(15)|0s</StoredType>
     </column>
-    <column id="443" parent="310" name="profile_img_url">
+    <column id="445" parent="310" name="profile_img_url">
       <Position>7</Position>
       <StoredType>tinytext|0s</StoredType>
     </column>
-    <column id="444" parent="310" name="role">
+    <column id="446" parent="310" name="role">
       <Position>8</Position>
       <StoredType>enum(&apos;ADMIN&apos;, &apos;USER&apos;)|0e</StoredType>
     </column>
-    <column id="445" parent="310" name="status_msg">
+    <column id="447" parent="310" name="status_msg">
       <Position>9</Position>
       <StoredType>varchar(50)|0s</StoredType>
     </column>
-    <index id="446" parent="310" name="PRIMARY">
+    <index id="448" parent="310" name="PRIMARY">
       <ColNames>id</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <index id="447" parent="310" name="UK6dotkott2kjsp8vw4d0m25fb7">
+    <index id="449" parent="310" name="UK6dotkott2kjsp8vw4d0m25fb7">
       <ColNames>email</ColNames>
       <Type>btree</Type>
       <Unique>1</Unique>
     </index>
-    <key id="448" parent="310" name="PRIMARY">
+    <key id="450" parent="310" name="PRIMARY">
       <NameSurrogate>1</NameSurrogate>
       <Primary>1</Primary>
       <UnderlyingIndexName>PRIMARY</UnderlyingIndexName>
     </key>
-    <key id="449" parent="310" name="UK6dotkott2kjsp8vw4d0m25fb7">
+    <key id="451" parent="310" name="UK6dotkott2kjsp8vw4d0m25fb7">
       <UnderlyingIndexName>UK6dotkott2kjsp8vw4d0m25fb7</UnderlyingIndexName>
     </key>
   </database-model>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/Koco.main.iml" filepath="$PROJECT_DIR$/.idea/modules/Koco.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/Koco.main.iml
+++ b/.idea/modules/Koco.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../Koco/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../Koco/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,24 +5,29 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/CategoryRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemCategoryRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetSolutionRespository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/SolutionRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/SurveyRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/ClusterRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserAlgorithmStatsRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserDetailRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/dataSources.local.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources.local.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules/Koco.main.iml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/AuthResponse.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/KakaoCallbackRequest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/KakaoTokenResponse.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/KakaoUserResponse.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/config/SecurityConfig.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/dto/ErrorResponse.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/ForbiddenException.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/ResourceNotFoundException.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/UnauthorizedException.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/entity/Cluster.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/entity/Cluster.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/build.gradle" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/entity/Solution.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/entity/Solution.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/resources/application.properties" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -83,36 +88,60 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;Gradle./Users/yeon/Documents/GitHub/21-iceT-be/demo/build.gradle.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.Build Koco.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.Koco.executor&quot;: &quot;Run&quot;,
-    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
-    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
-    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
-    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;Spring Boot.KocoApplication.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feat/4-entity-repository&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/yeon/Documents/GitHub/21-iceT-be&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "Gradle./Users/yeon/Documents/GitHub/21-iceT-be/demo/build.gradle.executor": "Run",
+    "Gradle.Build Koco.executor": "Run",
+    "Gradle.Koco.executor": "Run",
+    "Gradle.KocoApplicationTests.executor": "Run",
+    "RequestMappingsPanelOrder0": "0",
+    "RequestMappingsPanelOrder1": "1",
+    "RequestMappingsPanelWidth0": "75",
+    "RequestMappingsPanelWidth1": "75",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "Spring Boot.KocoApplication.executor": "Run",
+    "git-widget-placeholder": "feat/5-kakao-oauth",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/Users/yeon/Documents/GitHub/21-iceT-be",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;mysql&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "mysql"
     ]
   }
-}</component>
+}]]></component>
+  <component name="RecentsManager">
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/Koco" />
+    </key>
+  </component>
+  <component name="RunManager">
+    <configuration name="KocoApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
+      <envs>
+        <env name="DB_URL" value="jdbc:mysql://localhost:3306/Koco?useSSL=false&amp;serverTimezone=UTC&amp;allowPublicKeyRetrieval=true" />
+        <env name="DB_USERNAME" value="root" />
+        <env name="DB_PASSWORD" value="yeonwoo121!$" />
+        <env name="KAKAO_CLIENT_ID" value="c0d172ef34557eba95cfeb7246ed91eb" />
+        <env name="KAKAO_CLIENT_SECRET" value="vO3lebzvfIEpyZmizgScv7CL2qxwU9MW" />
+        <env name="KAKAO_REDIRECT_URI" value="http://localhost:8080/api/v1/auth/callback" />
+      </envs>
+      <module name="Koco.main" />
+      <option name="SPRING_BOOT_MAIN_CLASS" value="icet.koco.KocoApplication" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+  </component>
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
@@ -133,7 +162,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="6318000" />
+      <workItem from="1745971370107" duration="30761000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,16 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/LogoutResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/LogoutService.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/RefreshRequest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/RefreshResponse.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/build.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/KocoApplication.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/KocoApplication.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -150,7 +145,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="41136000" />
+      <workItem from="1745971370107" duration="42902000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,29 +5,16 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/modules/Koco.main.iml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/AuthResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/KakaoCallbackRequest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/KakaoTokenResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/KakaoUserResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/config/SecurityConfig.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/dto/ErrorResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/ForbiddenException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/ResourceNotFoundException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/UnauthorizedException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/dto/LogoutResponse.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/LogoutService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/build.gradle" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/KocoApplication.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/KocoApplication.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/entity/Solution.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/entity/Solution.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/resources/application.properties" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -111,7 +98,7 @@
     "node.js.selected.package.eslint": "(autodetect)",
     "node.js.selected.package.tslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "settings.editor.selected.configurable": "configurable.group.tools",
     "vue.rearranger.settings.migration": "true"
   },
   "keyToStringList": {
@@ -128,12 +115,13 @@
   <component name="RunManager">
     <configuration name="KocoApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
       <envs>
+        <env name="DB_PASSWORD" value="yeonwoo121!$" />
         <env name="DB_URL" value="jdbc:mysql://localhost:3306/Koco?useSSL=false&amp;serverTimezone=UTC&amp;allowPublicKeyRetrieval=true" />
         <env name="DB_USERNAME" value="root" />
-        <env name="DB_PASSWORD" value="yeonwoo121!$" />
         <env name="KAKAO_CLIENT_ID" value="c0d172ef34557eba95cfeb7246ed91eb" />
         <env name="KAKAO_CLIENT_SECRET" value="vO3lebzvfIEpyZmizgScv7CL2qxwU9MW" />
         <env name="KAKAO_REDIRECT_URI" value="http://localhost:8080/api/v1/auth/callback" />
+        <env name="JWT_SECRET" value="f9A8c7D6e5B4g3H2j1K0LmN9OpQ8rStUvWxYzZtQsPvNxLmKo" />
       </envs>
       <module name="Koco.main" />
       <option name="SPRING_BOOT_MAIN_CLASS" value="icet.koco.KocoApplication" />
@@ -162,7 +150,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="30761000" />
+      <workItem from="1745971370107" duration="41136000" />
     </task>
     <servers />
   </component>

--- a/Koco/build.gradle
+++ b/Koco/build.gradle
@@ -39,8 +39,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 처리를 위한 jackson 연동
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'	// swagger
-
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/Koco/build.gradle
+++ b/Koco/build.gradle
@@ -34,6 +34,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 처리를 위한 jackson 연동
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'	// swagger
+
 }
 
 tasks.named('test') {

--- a/Koco/src/main/java/icet/koco/KocoApplication.java
+++ b/Koco/src/main/java/icet/koco/KocoApplication.java
@@ -2,6 +2,7 @@ package icet.koco;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 public class KocoApplication {

--- a/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
+++ b/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
@@ -34,4 +34,13 @@ public class AuthController {
         return ResponseEntity.ok(logoutService.logout(request, response));
     }
 
+    @PostMapping("/refresh")
+    public ResponseEntity<RefreshResponse> refreshToken(@RequestBody RefreshRequest request,
+        HttpServletResponse response) {
+        RefreshResponse refreshResponse = authService.refreshAccessToken(request.getRefreshToken(), response);
+        return ResponseEntity.ok(refreshResponse);
+    }
+
+
+
 }

--- a/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
+++ b/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
@@ -2,14 +2,12 @@ package icet.koco.auth.controller;
 
 import icet.koco.auth.dto.*;
 import icet.koco.auth.service.AuthService;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import icet.koco.auth.service.LogoutService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.Operation;
-
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -17,12 +15,8 @@ import io.swagger.v3.oas.annotations.Operation;
 public class AuthController {
 
     private final AuthService authService;
+    private final LogoutService logoutService;
 
-
-    @Operation(
-        summary = "Kakao 로그인 callback",
-        description = "인가 코드로 액세스 토큰 발급 후 사용자 정보 반환"
-    )
     @CrossOrigin(origins = "*")
     @GetMapping("/callback")
     public ResponseEntity<AuthResponse> kakaoCallback(@RequestParam("code") String code,
@@ -32,6 +26,12 @@ public class AuthController {
         return ResponseEntity.ok(authResponse);
 
 
+    }
+
+    @CrossOrigin(origins = "*")
+    @PostMapping("/logout")
+    public ResponseEntity<LogoutResponse> logout(HttpServletRequest request, HttpServletResponse response) {
+        return ResponseEntity.ok(logoutService.logout(request, response));
     }
 
 }

--- a/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
+++ b/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
@@ -1,0 +1,37 @@
+package icet.koco.auth.controller;
+
+import icet.koco.auth.dto.*;
+import icet.koco.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+
+    @Operation(
+        summary = "Kakao 로그인 callback",
+        description = "인가 코드로 액세스 토큰 발급 후 사용자 정보 반환"
+    )
+    @CrossOrigin(origins = "*")
+    @GetMapping("/callback")
+    public ResponseEntity<AuthResponse> kakaoCallback(@RequestParam("code") String code,
+        HttpServletResponse response) {
+        System.out.println("인가코드: " + code);
+        AuthResponse authResponse = authService.loginWithKakao(code, response);
+        return ResponseEntity.ok(authResponse);
+
+
+    }
+
+}

--- a/Koco/src/main/java/icet/koco/auth/dto/AuthResponse.java
+++ b/Koco/src/main/java/icet/koco/auth/dto/AuthResponse.java
@@ -1,0 +1,24 @@
+package icet.koco.auth.dto;
+
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthResponse {
+    private String code;
+    private String message;
+    private AuthData data;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AuthData {
+        private String refreshToken;
+        private String email;
+        private String name;
+        private boolean isRegistered;
+    }
+}

--- a/Koco/src/main/java/icet/koco/auth/dto/KakaoCallbackRequest.java
+++ b/Koco/src/main/java/icet/koco/auth/dto/KakaoCallbackRequest.java
@@ -1,0 +1,11 @@
+package icet.koco.auth.dto;
+
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoCallbackRequest {
+    private String code;
+}

--- a/Koco/src/main/java/icet/koco/auth/dto/KakaoTokenResponse.java
+++ b/Koco/src/main/java/icet/koco/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,12 @@
+package icet.koco.auth.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoTokenResponse {
+    private String access_token;
+    private String refresh_token;
+}

--- a/Koco/src/main/java/icet/koco/auth/dto/KakaoUserResponse.java
+++ b/Koco/src/main/java/icet/koco/auth/dto/KakaoUserResponse.java
@@ -1,0 +1,33 @@
+package icet.koco.auth.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoUserResponse {
+    private Long id;
+    private KakaoAccount kakao_account;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class KakaoAccount {
+        private String email;
+        private String name;
+    }
+
+    public String getEmail() {
+        return kakao_account.getEmail();
+    }
+
+    public String getName() {
+        return kakao_account.getName();
+    }
+
+    public String getProviderId() {
+        return String.valueOf(id);
+    }
+}

--- a/Koco/src/main/java/icet/koco/auth/dto/LogoutResponse.java
+++ b/Koco/src/main/java/icet/koco/auth/dto/LogoutResponse.java
@@ -1,0 +1,27 @@
+package icet.koco.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LogoutResponse {
+    private String code;
+    private String message;
+    private Data data;
+
+    @Builder
+    public LogoutResponse(String code, String message, String redirectUrl) {
+        this.code = code;
+        this.message = message;
+        this.data = new Data(redirectUrl);
+    }
+
+    @Getter
+    public static class Data {
+        private final String redirectUrl;
+
+        public Data(String redirectUrl) {
+            this.redirectUrl = redirectUrl;
+        }
+    }
+}

--- a/Koco/src/main/java/icet/koco/auth/dto/RefreshRequest.java
+++ b/Koco/src/main/java/icet/koco/auth/dto/RefreshRequest.java
@@ -1,0 +1,10 @@
+package icet.koco.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RefreshRequest {
+    private String refreshToken;
+}

--- a/Koco/src/main/java/icet/koco/auth/dto/RefreshResponse.java
+++ b/Koco/src/main/java/icet/koco/auth/dto/RefreshResponse.java
@@ -1,0 +1,16 @@
+package icet.koco.auth.dto;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+// 응답 DTO
+@Getter
+@Setter
+@Builder
+public class RefreshResponse {
+    private String code;
+    private String message;
+    private Map<String, String> data;
+}

--- a/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java
+++ b/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java
@@ -4,6 +4,9 @@ import icet.koco.auth.entity.OAuth;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface OAuthRepository extends JpaRepository<OAuth, Long> {
 
@@ -15,4 +18,10 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
 
     // user_id로 OAuth 정보 조회
     Optional<OAuth> findByUserId(Long userId);
+
+    // 사용자 ID로 refresh token을 갱신합니다.
+    @Transactional
+    @Modifying
+    @Query("UPDATE OAuth o SET o.refreshToken = :refreshToken WHERE o.user.id = :userId")
+    void updateRefreshToken(Long userId, String refreshToken);
 }

--- a/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java
+++ b/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java
@@ -24,4 +24,5 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
     @Modifying
     @Query("UPDATE OAuth o SET o.refreshToken = :refreshToken WHERE o.user.id = :userId")
     void updateRefreshToken(Long userId, String refreshToken);
+
 }

--- a/Koco/src/main/java/icet/koco/auth/service/AuthService.java
+++ b/Koco/src/main/java/icet/koco/auth/service/AuthService.java
@@ -1,0 +1,84 @@
+package icet.koco.auth.service;
+
+
+import icet.koco.auth.dto.AuthResponse;
+import icet.koco.auth.dto.KakaoUserResponse;
+import icet.koco.auth.entity.OAuth;
+import icet.koco.auth.repository.OAuthRepository;
+import icet.koco.global.exception.UnauthorizedException;
+import icet.koco.user.entity.User;
+import icet.koco.user.repository.UserRepository;
+import icet.koco.util.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final UserRepository userRepository;
+    private final OAuthRepository oauthRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthResponse loginWithKakao(String code, HttpServletResponse response) {
+        KakaoUserResponse kakaoUser = kakaoOAuthClient.getUserInfo(code);
+        Optional<User> userOpt = userRepository.findByEmail(kakaoUser.getEmail());
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            String refreshToken = jwtTokenProvider.createRefreshToken(user);
+            oauthRepository.updateRefreshToken(user.getId(), refreshToken);
+
+            Cookie cookie = new Cookie("accessToken", jwtTokenProvider.createAccessToken(user));
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            response.addCookie(cookie);
+
+            return AuthResponse.builder()
+                .code("LOGIN_SUCCESS")
+                .message("로그인 성공. 토큰 발급 완료")
+                .data(AuthResponse.AuthData.builder()
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .refreshToken(refreshToken)
+                    .isRegistered(true)
+                    .build())
+                .build();
+        }
+
+        // 신규 회원
+        User newUser = userRepository.save(User.builder()
+            .email(kakaoUser.getEmail())
+            .name(kakaoUser.getName())
+            .createdAt(LocalDateTime.now())
+            .build());
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(newUser);
+        oauthRepository.save(OAuth.builder()
+            .provider("kakao")
+            .providerId(kakaoUser.getProviderId())
+            .user(newUser)
+            .refreshToken(refreshToken)
+            .build());
+
+        Cookie cookie = new Cookie("accessToken", jwtTokenProvider.createAccessToken(newUser));
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return AuthResponse.builder()
+            .code("LOGIN_SUCCESS")
+            .message("로그인 성공. 토큰 발급 완료")
+            .data(AuthResponse.AuthData.builder()
+                .email(newUser.getEmail())
+                .name(newUser.getName())
+                .refreshToken(refreshToken)
+                .isRegistered(false)
+                .build())
+            .build();
+    }
+}

--- a/Koco/src/main/java/icet/koco/auth/service/AuthService.java
+++ b/Koco/src/main/java/icet/koco/auth/service/AuthService.java
@@ -1,11 +1,9 @@
 package icet.koco.auth.service;
 
-
 import icet.koco.auth.dto.AuthResponse;
 import icet.koco.auth.dto.KakaoUserResponse;
 import icet.koco.auth.entity.OAuth;
 import icet.koco.auth.repository.OAuthRepository;
-import icet.koco.global.exception.UnauthorizedException;
 import icet.koco.user.entity.User;
 import icet.koco.user.repository.UserRepository;
 import icet.koco.util.JwtTokenProvider;
@@ -13,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.data.redis.core.RedisTemplate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -24,16 +23,25 @@ public class AuthService {
     private final UserRepository userRepository;
     private final OAuthRepository oauthRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public AuthResponse loginWithKakao(String code, HttpServletResponse response) {
         KakaoUserResponse kakaoUser = kakaoOAuthClient.getUserInfo(code);
         Optional<User> userOpt = userRepository.findByEmail(kakaoUser.getEmail());
         if (userOpt.isPresent()) {
             User user = userOpt.get();
-            String refreshToken = jwtTokenProvider.createRefreshToken(user);
-            oauthRepository.updateRefreshToken(user.getId(), refreshToken);
 
-            Cookie cookie = new Cookie("accessToken", jwtTokenProvider.createAccessToken(user));
+            // RefreshToken Redis에 저장
+            String refreshToken = jwtTokenProvider.createRefreshToken(user);
+            redisTemplate.opsForValue().set(user.getId().toString(), refreshToken);
+
+            oauthRepository.updateRefreshToken(user.getId(), refreshToken);
+            String accessToken = jwtTokenProvider.createAccessToken(user);
+
+            // Token(access, refresh) 발급 확인용
+            System.out.println(">>>>> (AuthService: loginWithKakao) Access token: " + accessToken);
+            System.out.println(">>>>> (AuthService: loginWithKakao) Refresh token: " + refreshToken);
+            Cookie cookie = new Cookie("accessToken", accessToken);
             cookie.setHttpOnly(true);
             cookie.setPath("/");
             response.addCookie(cookie);

--- a/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java
+++ b/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java
@@ -1,0 +1,46 @@
+package icet.koco.auth.service;
+
+import icet.koco.auth.dto.KakaoTokenResponse;
+import icet.koco.auth.dto.KakaoUserResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class KakaoOAuthClient {
+
+    @Value("${KAKAO_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${KAKAO_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String redirectUri;
+
+    private final WebClient webClient = WebClient.create();
+
+    public KakaoUserResponse getUserInfo(String code) {
+        System.out.println("받은 인가코드: " + code);
+        System.out.println("clientId: " + clientId);
+        System.out.println("redirectUri: " + redirectUri);
+        String token = webClient.post()
+            .uri("https://kauth.kakao.com/oauth/token")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .bodyValue("grant_type=authorization_code&client_id=" + clientId +
+                "&client_secret=" + clientSecret +
+                "&redirect_uri=" + redirectUri + "&code=" + code)
+            .retrieve()
+            .bodyToMono(KakaoTokenResponse.class)
+            .block()
+            .getAccess_token();
+
+        return webClient.get()
+            .uri("https://kapi.kakao.com/v2/user/me")
+            .header("Authorization", "Bearer " + token)
+            .retrieve()
+            .bodyToMono(KakaoUserResponse.class)
+            .block();
+    }
+}
+

--- a/Koco/src/main/java/icet/koco/auth/service/LogoutService.java
+++ b/Koco/src/main/java/icet/koco/auth/service/LogoutService.java
@@ -1,0 +1,76 @@
+package icet.koco.auth.service;
+
+import icet.koco.auth.dto.LogoutResponse;
+import icet.koco.auth.repository.OAuthRepository;
+import icet.koco.global.exception.UnauthorizedException;
+import icet.koco.util.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+
+    private final OAuthRepository oauthRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public LogoutResponse logout(HttpServletRequest request, HttpServletResponse response) {
+        // 1. 쿠키에서 accessToken 추출
+        String accessToken = extractTokenFromCookies(request);
+        System.out.println(">>>>> (LogoutServie) accessToken: " + accessToken);
+
+        // 2. 유효성 검사
+        if (accessToken == null || !jwtTokenProvider.validateToken(accessToken)) {
+            if (accessToken == null) {
+                System.out.println(">>>>> (LogoutServie) Invalid access token");
+            }
+            throw new UnauthorizedException("유효하지 않은 토큰입니다.");
+        }
+
+        // 3. 토큰에서 userId 추출
+        Long userId = jwtTokenProvider.getUserIdFromToken(accessToken);
+        System.out.println("userId = " + userId);
+
+        // 4. DB에서 RefreshToken null로 만들기
+        oauthRepository.findByUserId(userId).ifPresent(oAuth -> {
+            oAuth.setRefreshToken(null);
+            oauthRepository.save(oAuth);
+        });
+
+        // 5. Redis에서도 삭제
+        redisTemplate.delete(userId.toString());
+
+        // 6. 쿠키 제거
+        invalidateAccessTokenCookie(response);
+
+        // 7. 응답 반환
+        return LogoutResponse.builder()
+            .code("LOGOUT_SUCCESS")
+            .message("로그아웃 성공.")
+            .redirectUrl("/api/v1/auth/login/") // To-Do: 프론트 도메인 나중에 연결
+            .build();
+    }
+
+    private String extractTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if ("access_token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    private void invalidateAccessTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("access_token", null);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+    }
+}

--- a/Koco/src/main/java/icet/koco/config/SecurityConfig.java
+++ b/Koco/src/main/java/icet/koco/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package icet.koco.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
+                    "/swagger-resources/**",
+                    "/webjars/**",
+                    "/api/v1/auth/**"
+                ).permitAll()
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/Koco/src/main/java/icet/koco/global/dto/ErrorResponse.java
+++ b/Koco/src/main/java/icet/koco/global/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package icet.koco.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+    private Object data; // 항상 null로 응답
+}

--- a/Koco/src/main/java/icet/koco/global/exception/ForbiddenException.java
+++ b/Koco/src/main/java/icet/koco/global/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package icet.koco.global.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java
+++ b/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java
@@ -35,12 +35,14 @@ public class GlobalExceptionHandler {
     // 500 (그 외 모든 예외)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleInternal(Exception ex, HttpServletRequest request) {
-        // Swagger 문서 요청은 예외 처리하지 않고 pass
+        // Swagger 요청은 예외를 아예 응답 없이 무시함
         if (request.getRequestURI().contains("/v3/api-docs")) {
-            throw new RuntimeException(ex); // 그냥 원래 예외를 다시 던져 Swagger가 처리하게 함
+            return ResponseEntity.ok().build(); // 예외를 던지지 말고 200 OK로 응답
         }
+
         return buildErrorResponse("INTERNAL_SERVER_ERROR", "서버에서 에러가 발생하였습니다", HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
 
     // 공통 응답 생성 함수
     private ResponseEntity<ErrorResponse> buildErrorResponse(String code, String message, HttpStatus status) {

--- a/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java
+++ b/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,54 @@
+package icet.koco.global.exception;
+
+import icet.koco.global.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // 400
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException ex) {
+        return buildErrorResponse("BAD_REQUEST", ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    // 401
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorized(UnauthorizedException ex) {
+        return buildErrorResponse("UNAUTHORIZED", ex.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    // 403
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbidden(ForbiddenException ex) {
+        return buildErrorResponse("FORBIDDEN", ex.getMessage(), HttpStatus.FORBIDDEN);
+    }
+
+    // 404
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException ex) {
+        return buildErrorResponse("NOT_FOUND", ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    // 500 (그 외 모든 예외)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleInternal(Exception ex, HttpServletRequest request) {
+        // Swagger 문서 요청은 예외 처리하지 않고 pass
+        if (request.getRequestURI().contains("/v3/api-docs")) {
+            throw new RuntimeException(ex); // 그냥 원래 예외를 다시 던져 Swagger가 처리하게 함
+        }
+        return buildErrorResponse("INTERNAL_SERVER_ERROR", "서버에서 에러가 발생하였습니다", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // 공통 응답 생성 함수
+    private ResponseEntity<ErrorResponse> buildErrorResponse(String code, String message, HttpStatus status) {
+        return ResponseEntity.status(status)
+            .body(ErrorResponse.builder()
+                .code(code)
+                .message(message)
+                .data(null)
+                .build());
+    }
+}

--- a/Koco/src/main/java/icet/koco/global/exception/ResourceNotFoundException.java
+++ b/Koco/src/main/java/icet/koco/global/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package icet.koco.global.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/Koco/src/main/java/icet/koco/global/exception/UnauthorizedException.java
+++ b/Koco/src/main/java/icet/koco/global/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package icet.koco.global.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/Koco/src/main/java/icet/koco/problemSet/entity/Solution.java
+++ b/Koco/src/main/java/icet/koco/problemSet/entity/Solution.java
@@ -26,9 +26,17 @@ public class Solution {
     @JoinColumn(name = "problem_id", nullable = false)
     private Problem problem;
 
-    // 문제 해설 본문
-    @Column(name = "explanation", nullable = false, columnDefinition = "TEXT")
-    private String explanation;
+    // 문제 개요
+    @Column(name = "problem_description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    // 문제 알고리즘 설명
+    @Column(name = "algorithm", nullable = false, columnDefinition = "TEXT")
+    private String algorithm;
+
+    // 문제 해결 방법
+    @Column(name = "problem_solving", nullable = false, columnDefinition = "TEXT")
+    private String problemSolving;
 
     // C++ 코드
     @Column(name = "code_cpp", nullable = false, columnDefinition = "TEXT")

--- a/Koco/src/main/java/icet/koco/user/repository/UserRepository.java
+++ b/Koco/src/main/java/icet/koco/user/repository/UserRepository.java
@@ -13,6 +13,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 닉네임으로 유저 조회
     Optional<User> findByNickname(String nickname);
 
+    // 이메일으로 유저 조회
+    Optional<User> findByEmail(String email);
+
     // ID로 조회하면서 soft delete 제외
     Optional<User> findByIdAndDeletedAtIsNull(Long id);
 

--- a/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
+++ b/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
@@ -1,0 +1,61 @@
+package icet.koco.util;
+
+import icet.koco.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private SecretKey key;
+    private final long accessTokenValidity = 1000 * 60 * 30; // 30분
+    private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 14; // 14일
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    }
+
+    public String createAccessToken(User user) {
+        return Jwts.builder()
+            .setSubject(user.getId().toString())
+            .claim("email", user.getEmail())
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidity))
+            .signWith(key)
+            .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        return Jwts.builder()
+            .setSubject(user.getId().toString())
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidity))
+            .signWith(key)
+            .compact();
+    }
+
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(key).build()
+            .parseClaimsJws(token)
+            .getBody();
+        return Long.valueOf(claims.getSubject());
+    }
+}

--- a/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
+++ b/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
@@ -9,10 +9,14 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import java.util.Date;
 import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider {
+
+    @Value("${JWT_SECRET}")
+    private String secret;
 
     private SecretKey key;
     private final long accessTokenValidity = 1000 * 60 * 30; // 30분
@@ -20,7 +24,7 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void init() {
-        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
     }
 
     public String createAccessToken(User user) {

--- a/Koco/src/main/resources/application.properties
+++ b/Koco/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=Koco
-spring.datasource.url=jdbc:mysql://localhost:3306/Koco?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-spring.datasource.username=root
-spring.datasource.password=yeonwoo121!$
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true


### PR DESCRIPTION
## 📝 개요
- Kakao OAuth 2.0 인증 기반 로그인/로그아웃/AccessToken 재발급 기능 구현
- AccessToken은 쿠키(HttpOnly)에, RefreshToken은 DB+Redis에 저장
- 토큰 만료 시 RefreshToken을 통해 자동 재발급 처리

## 🔗 연관된 이슈
- #5 

## 🔄 변경사항 및 이유
- `AuthService`
    - `loginWithKakao()` 구현: code → 사용자 정보 조회 → JWT 발급 → 쿠키/DB 저장
    - `refreshAccessToken()` 구현: refreshToken 검증 후 accessToken 재발급
    - `logout()` 구현: 쿠키 제거 + Redis/DB RefreshToken 삭제
- `JwtTokenProvider`
    - JWT 생성/파싱/검증 메서드 구현
    - 만료시간 설정 (AccessToken: 30분 / RefreshToken: 14일)
- Redis 사용을 위한 `RedisTemplate` 설정 적용

## 📋 작업한 내용
- [x] 백엔드 구현 (KakaoOAuthClient, TokenProvider, AuthService 등)
- [x] 백엔드 로컬 redirectUrl로 추가하여 인가코드 발급 확인 완료
- [x] Redis를 이용하여 로그인 / 로그아웃 구현
- [x] Postman으로 전체 흐름 테스트 완료

## 🔖 기타사항
- 이후 프론트 도메인 확정 시 redirectUrl 수정 필요

## 👀 리뷰 요구사항
- 토큰 만료 시간과 쿠키 유효 시간 동기화가 적절한지 확인 부탁드립니다.
- RefreshToken 저장을 Redis + DB 이중으로 하는 방식이 과한지 검토 부탁드립니다.
- 보안을 위해 RefreshToken을 통해서 재발급할 때 발급받은 IP와 같은지 확인하는 과정이 추가적으로 필요할지 검토 부탁드립니다.
- 현재 모든 요청, 응답에 대해서 Dto class를 다 만들고 있는데 너무 불필요한 작업인지 피드백 부탁드립니다. 

## 🔗 참고 자료
- [Kakao REST API](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)
- [Koco API Sheet](https://docs.google.com/spreadsheets/d/1wYadCvRPv5xngdMaQ6ABndTsXOb6mPNtnI97TJArCt8/edit?gid=404344451#gid=404344451)