### PR TITLE
[Feat] 문제집 설문 응답 기능 구현 (#9)

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -116,6 +116,7 @@
         <env name="KAKAO_CLIENT_SECRET" value="vO3lebzvfIEpyZmizgScv7CL2qxwU9MW" />
         <env name="KAKAO_REDIRECT_URI" value="http://localhost:8080/api/v1/auth/callback" />
         <env name="JWT_SECRET" value="f9A8c7D6e5B4g3H2j1K0LmN9OpQ8rStUvWxYzZtQsPvNxLmKo" />
+        <env name="KAKAO_ADMIN_KEY" value="4fdc95eb0a877e45eba174f44fbd90c7" />
       </envs>
       <module name="Koco.main" />
       <option name="SPRING_BOOT_MAIN_CLASS" value="icet.koco.KocoApplication" />
@@ -144,7 +145,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="85276000" />
+      <workItem from="1745971370107" duration="95428000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSetSurveyRequestDto.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/SurveyResponseDto.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -146,7 +144,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="83346000" />
+      <workItem from="1745971370107" duration="85276000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSetSurveyRequestDto.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/dto/SurveyResponseDto.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -83,7 +86,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Spring Boot.KocoApplication.executor": "Run",
-    "git-widget-placeholder": "#14 on feat/8-problemset-by-date",
+    "git-widget-placeholder": "feat/9-survey-response",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/yeon/Documents/GitHub/21-iceT-be",
     "node.js.detected.package.eslint": "true",
@@ -143,7 +146,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="78619000" />
+      <workItem from="1745971370107" duration="83346000" />
     </task>
     <servers />
   </component>

--- a/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
@@ -1,0 +1,30 @@
+package icet.koco.problemSet.controller;
+
+import icet.koco.problemSet.dto.ProblemSetSurveyRequestDto;
+import icet.koco.problemSet.dto.SurveyResponseDto;
+import icet.koco.problemSet.service.SurveyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/problem-set/surveys")
+@RequiredArgsConstructor
+public class SurveyController {
+
+    private final SurveyService surveyService;
+
+    @PostMapping
+    public ResponseEntity<SurveyResponseDto> submitSurvey(
+        @RequestBody ProblemSetSurveyRequestDto requestDto
+    ) {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        SurveyResponseDto response = surveyService.submitSurvey(userId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSetSurveyRequestDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSetSurveyRequestDto.java
@@ -1,0 +1,10 @@
+package icet.koco.problemSet.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ProblemSetSurveyRequestDto {
+    private Long problemSetId;
+    private List<ProblemSurveyRequestDto> responses;
+}

--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
@@ -1,0 +1,14 @@
+package icet.koco.problemSet.dto;
+
+import icet.koco.enums.DifficultyLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProblemSurveyRequestDto {
+    private Long id;
+    private Long problemId;
+    private boolean isSolved;
+    private String difficultyLevel;
+}

--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ProblemSurveyRequestDto {
-    private Long id;
     private Long problemId;
     private boolean isSolved;
     private String difficultyLevel;

--- a/Koco/src/main/java/icet/koco/problemSet/dto/SurveyResponseDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/SurveyResponseDto.java
@@ -1,0 +1,14 @@
+package icet.koco.problemSet.dto;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SurveyResponseDto {
+    private String code;
+    private String message;
+    private Map<String, List<Long>> data;
+}

--- a/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java
@@ -32,4 +32,8 @@ public interface ProblemSetProblemRepository extends JpaRepository<ProblemSetPro
     @Query("SELECT psp FROM ProblemSetProblem psp JOIN FETCH psp.problem WHERE psp.problemSet = :problemSet")
     List<ProblemSetProblem> findWithProblemsByProblemSet(@Param("problemSet") ProblemSet problemSet);
 
+    @Query("SELECT p.problem.id FROM ProblemSetProblem p WHERE p.problemSet.id = :problemSetId AND p.problem.id IN :problemIds")
+    List<Long> findIncludedProblemIds(@Param("problemSetId") Long problemSetId, @Param("problemIds") List<Long> problemIds);
+
+
 }

--- a/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java
@@ -26,6 +26,8 @@ public interface ProblemSetProblemRepository extends JpaRepository<ProblemSetPro
     // 문제집(ProblemSet)에 포함된 문제 전체 조회
     List<ProblemSetProblem> findAllByProblemSet(ProblemSet problemSet);
 
+    boolean existsByProblemSetIdAndProblemId(Long problemSetId, Long problemId);
+
     // ProblemSetProblemRepository.java
     @Query("SELECT psp FROM ProblemSetProblem psp JOIN FETCH psp.problem WHERE psp.problemSet = :problemSet")
     List<ProblemSetProblem> findWithProblemsByProblemSet(@Param("problemSet") ProblemSet problemSet);

--- a/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
@@ -29,7 +29,7 @@ public class ProblemSetService {
 
     @Transactional(readOnly = true)
     public ProblemSetResponseDto getProblemSetByDate(Long userId, LocalDate date) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
             .orElseThrow(() -> new ForbiddenException("사용자를 찾을 수 없습니다."));
 
         ProblemSet problemSet = problemSetRepository.findByCreatedAt(date)

--- a/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
@@ -16,10 +16,9 @@ import icet.koco.problemSet.repository.SurveyRepository;
 import icet.koco.user.entity.User;
 import icet.koco.user.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,53 +36,57 @@ public class SurveyService {
 
     @Transactional
     public SurveyResponseDto submitSurvey(Long userId, ProblemSetSurveyRequestDto requestDto) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
             .orElseThrow(() -> new UnauthorizedException("존재하지 않는 사용자입니다."));
-        log.info(">>>>> 사용자 ID: {}", userId);
 
-        ProblemSet problemSet = problemSetRepository.findById(requestDto.getProblemSetId())
+        Long problemSetId = requestDto.getProblemSetId();
+        ProblemSet problemSet = problemSetRepository.findById(problemSetId)
             .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 문제집입니다."));
-        log.info(">>>>> 문제집 번호: {}", problemSet.getId());
+
+        Set<Long> requestProblemIds = requestDto.getResponses().stream()
+            .map(ProblemSurveyRequestDto::getProblemId)
+            .collect(Collectors.toSet());
+
+        Map<Long, Problem> problemMap = problemRepository.findAllById(requestProblemIds).stream()
+            .collect(Collectors.toMap(Problem::getId, p -> p));
+
+        // 포함된 문제 ID만 조회 (JPQL 기반)
+        List<Long> includedIds = problemSetProblemRepository
+            .findIncludedProblemIds(problemSetId, new ArrayList<>(requestProblemIds));
+        Set<Long> includedProblemIds = new HashSet<>(includedIds);
 
         List<Survey> surveysToSave = new ArrayList<>();
 
         for (ProblemSurveyRequestDto response : requestDto.getResponses()) {
-            Problem problem = problemRepository.findById(response.getProblemId())
-                .orElseThrow(() -> new ResourceNotFoundException(">>>>> 문제 ID " + response.getProblemId() + "가 존재하지 않습니다."));
+            Long pid = response.getProblemId();
 
-            // 문제 Id가 해당 ProblemSet에 있는지 검증
-            boolean exists = problemSetProblemRepository.existsByProblemSetIdAndProblemId(problemSet.getId(), problem.getId());
-            if (!exists) {
-                throw new UnauthorizedException("문제 ID " + problem.getId() + "는 문제집 " + problemSet.getId() + "에 포함되어 있지 않습니다.");
+            Problem problem = problemMap.get(pid);
+            if (problem == null) {
+                throw new ResourceNotFoundException("문제 ID " + pid + "가 존재하지 않습니다.");
             }
-
-            log.info(">>>>> 문제 번호: {}", problem.getId());
+            if (!includedProblemIds.contains(pid)) {
+                throw new UnauthorizedException("문제 ID " + pid + "는 문제집 " + problemSetId + "에 포함되어 있지 않습니다.");
+            }
 
             Survey survey = Survey.builder()
                 .user(user)
                 .problemSet(problemSet)
                 .problem(problem)
                 .isSolved(response.isSolved())
-                .difficultyLevel(DifficultyLevel.valueOf(response.getDifficultyLevel()))
+                .difficultyLevel(DifficultyLevel.valueOf(response.getDifficultyLevel().toUpperCase()))
                 .answeredAt(LocalDateTime.now())
                 .build();
 
             surveysToSave.add(survey);
         }
 
-        // 디비에 넣기 한 번에 수행
-        List<Survey> savedSurveys = surveyRepository.saveAll(surveysToSave);
-
-        List<Long> savedIds = savedSurveys.stream()
-            .map(Survey::getId)
-            .toList();
-
-        log.info(">>>>> 저장된 설문 ID 목록: {}", savedIds);
+        List<Survey> saved = surveyRepository.saveAll(surveysToSave);
+        List<Long> ids = saved.stream().map(Survey::getId).toList();
 
         return SurveyResponseDto.builder()
             .code("SURVEY_CREATED")
             .message("출제 문제집에 대한 설문응답이 성공적으로 생성되었습니다.")
-            .data(Map.of("surveyId", savedIds))
+            .data(Map.of("surveyId", ids))
             .build();
     }
 }

--- a/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
@@ -1,0 +1,68 @@
+package icet.koco.problemSet.service;
+
+import icet.koco.enums.DifficultyLevel;
+import icet.koco.global.exception.ResourceNotFoundException;
+import icet.koco.global.exception.UnauthorizedException;
+import icet.koco.problemSet.dto.ProblemSetSurveyRequestDto;
+import icet.koco.problemSet.dto.ProblemSurveyRequestDto;
+import icet.koco.problemSet.dto.SurveyResponseDto;
+import icet.koco.problemSet.entity.Problem;
+import icet.koco.problemSet.entity.ProblemSet;
+import icet.koco.problemSet.entity.Survey;
+import icet.koco.problemSet.repository.ProblemRepository;
+import icet.koco.problemSet.repository.ProblemSetRepository;
+import icet.koco.problemSet.repository.SurveyRepository;
+import icet.koco.user.entity.User;
+import icet.koco.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyService {
+
+    private final UserRepository userRepository;
+    private final ProblemSetRepository problemSetRepository;
+    private final ProblemRepository problemRepository;
+    private final SurveyRepository surveyRepository;
+
+    @Transactional
+    public SurveyResponseDto submitSurvey(Long userId, ProblemSetSurveyRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UnauthorizedException("존재하지 않는 사용자입니다."));
+
+        ProblemSet problemSet = problemSetRepository.findById(requestDto.getProblemSetId())
+            .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 문제집입니다."));
+
+        List<Long> savedIds = new ArrayList<>();
+
+        for (ProblemSurveyRequestDto response : requestDto.getResponses()) {
+            Problem problem = problemRepository.findById(response.getProblemId())
+                .orElseThrow(() -> new ResourceNotFoundException("문제 ID " +response.getProblemId() + "가 존재하지 않습니다."));
+
+            Survey survey = Survey.builder()
+                .user(user)
+                .problemSet(problemSet)
+                .problem(problem)
+                .isSolved(response.isSolved())
+//                .isSolved(response.getIsSolved())
+                .difficultyLevel(DifficultyLevel.valueOf(response.getDifficultyLevel()))
+                .answeredAt(LocalDateTime.now())
+                .build();
+
+            surveyRepository.save(survey);
+            savedIds.add(survey.getId());
+        }
+
+        return SurveyResponseDto.builder()
+            .code("SURVEY_CREATED")
+            .message("출제 문제집에 대한 설문응답이 성공적으로 생성되었습니다.")
+            .data(Map.of("surveyId", savedIds))
+            .build();
+    }
+}

--- a/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
@@ -10,6 +10,7 @@ import icet.koco.problemSet.entity.Problem;
 import icet.koco.problemSet.entity.ProblemSet;
 import icet.koco.problemSet.entity.Survey;
 import icet.koco.problemSet.repository.ProblemRepository;
+import icet.koco.problemSet.repository.ProblemSetProblemRepository;
 import icet.koco.problemSet.repository.ProblemSetRepository;
 import icet.koco.problemSet.repository.SurveyRepository;
 import icet.koco.user.entity.User;
@@ -19,9 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SurveyService {
@@ -30,34 +33,52 @@ public class SurveyService {
     private final ProblemSetRepository problemSetRepository;
     private final ProblemRepository problemRepository;
     private final SurveyRepository surveyRepository;
+    private final ProblemSetProblemRepository problemSetProblemRepository;
 
     @Transactional
     public SurveyResponseDto submitSurvey(Long userId, ProblemSetSurveyRequestDto requestDto) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UnauthorizedException("존재하지 않는 사용자입니다."));
+        log.info(">>>>> 사용자 ID: {}", userId);
 
         ProblemSet problemSet = problemSetRepository.findById(requestDto.getProblemSetId())
             .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 문제집입니다."));
+        log.info(">>>>> 문제집 번호: {}", problemSet.getId());
 
-        List<Long> savedIds = new ArrayList<>();
+        List<Survey> surveysToSave = new ArrayList<>();
 
         for (ProblemSurveyRequestDto response : requestDto.getResponses()) {
             Problem problem = problemRepository.findById(response.getProblemId())
-                .orElseThrow(() -> new ResourceNotFoundException("문제 ID " +response.getProblemId() + "가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResourceNotFoundException(">>>>> 문제 ID " + response.getProblemId() + "가 존재하지 않습니다."));
+
+            // 문제 Id가 해당 ProblemSet에 있는지 검증
+            boolean exists = problemSetProblemRepository.existsByProblemSetIdAndProblemId(problemSet.getId(), problem.getId());
+            if (!exists) {
+                throw new UnauthorizedException("문제 ID " + problem.getId() + "는 문제집 " + problemSet.getId() + "에 포함되어 있지 않습니다.");
+            }
+
+            log.info(">>>>> 문제 번호: {}", problem.getId());
 
             Survey survey = Survey.builder()
                 .user(user)
                 .problemSet(problemSet)
                 .problem(problem)
                 .isSolved(response.isSolved())
-//                .isSolved(response.getIsSolved())
                 .difficultyLevel(DifficultyLevel.valueOf(response.getDifficultyLevel()))
                 .answeredAt(LocalDateTime.now())
                 .build();
 
-            surveyRepository.save(survey);
-            savedIds.add(survey.getId());
+            surveysToSave.add(survey);
         }
+
+        // 디비에 넣기 한 번에 수행
+        List<Survey> savedSurveys = surveyRepository.saveAll(surveysToSave);
+
+        List<Long> savedIds = savedSurveys.stream()
+            .map(Survey::getId)
+            .toList();
+
+        log.info(">>>>> 저장된 설문 ID 목록: {}", savedIds);
 
         return SurveyResponseDto.builder()
             .code("SURVEY_CREATED")


### PR DESCRIPTION
## 📝 개요
- `POST /api/v1/problem-set/surveys` API로 출제 문제집에 대한 사용자 설문 응답 기능을 구현했습니다.

## 🔗 연관된 이슈
- #9 

## 📋 작업한 내용
- [X] `SurveyService` 생성 및 설문 저장 로직 구현
- [X] 설문 응답 요청을 처리하는 `SurveyController` 추가
- [X] `Survey`, `ProblemSet`, `Problem` 간 유효성 검증 로직 포함
- [X] 데이터 정합성 위해 문제집에 속하지 않은 문제에 대해 예외 발생하도록 설계

## 🔖 기타사항
- [ ] 사용자 응답 시점(answeredAt)은 서버 시간 기준으로 자동 기록되며, 프론트에서 별도 전달하지 않음
- [ ] 추후 설문 데이터가 많아질 경우 조회/통계에 대한 인덱싱 고려 필요

## 👀 리뷰 요구사항
- [x] 제가 dev 브랜치로 머지하는지 체크 한번만 부탁드려요...!!!
- `submitSurvey()`에서 문제와 문제집 매핑 검증 방식이 적절한지 확인 부탁드립니다.

