### PR TITLE
[Feat] 사용자 탈퇴 기능 구현 (#12)

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/CookieUtil.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/TokenExtractor.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SolutionService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/LogoutService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/LogoutService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -148,7 +143,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="98965000" />
+      <workItem from="1745971370107" duration="102384000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -84,7 +89,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Spring Boot.KocoApplication.executor": "Run",
-    "git-widget-placeholder": "feat/9-survey-response",
+    "git-widget-placeholder": "feat/12-user-withdrawl",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/yeon/Documents/GitHub/21-iceT-be",
     "node.js.detected.package.eslint": "true",
@@ -145,7 +150,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="95428000" />
+      <workItem from="1745971370107" duration="96628000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/config/WebClientConfig.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -144,7 +145,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="96966000" />
+      <workItem from="1745971370107" duration="97307000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/AuthService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/repository/UserRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -150,7 +144,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="96628000" />
+      <workItem from="1745971370107" duration="96966000" />
     </task>
     <servers />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,10 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="04cb8b11-cbc8-4aa1-a304-6ecca318280e" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/config/WebClientConfig.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/CookieUtil.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/util/TokenExtractor.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/controller/AuthController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/LogoutService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/auth/service/LogoutService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/controller/UserController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" beforeDir="false" afterPath="$PROJECT_DIR$/Koco/src/main/java/icet/koco/user/service/UserService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -145,7 +148,7 @@
       <workItem from="1745890171095" duration="11672000" />
       <workItem from="1745905877463" duration="27840000" />
       <workItem from="1745971219995" duration="134000" />
-      <workItem from="1745971370107" duration="97307000" />
+      <workItem from="1745971370107" duration="98965000" />
     </task>
     <servers />
   </component>

--- a/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
+++ b/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
         @CookieValue(value = "refresh_token", required = true) String refreshToken,
         HttpServletResponse response)
     {
-        System.out.println("refreshToken: " + refreshToken);
+        System.out.println("refresh_token: " + refreshToken);
         RefreshResponse refreshResponse = authService.refreshAccessToken(refreshToken, response);
         return ResponseEntity.ok(refreshResponse);
     }

--- a/Koco/src/main/java/icet/koco/auth/service/AuthService.java
+++ b/Koco/src/main/java/icet/koco/auth/service/AuthService.java
@@ -9,7 +9,6 @@ import icet.koco.global.exception.UnauthorizedException;
 import icet.koco.user.entity.User;
 import icet.koco.user.repository.UserRepository;
 import icet.koco.util.JwtTokenProvider;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import jakarta.servlet.http.Cookie;
@@ -33,6 +32,12 @@ public class AuthService {
         Optional<User> userOpt = userRepository.findByEmail(kakaoUser.getEmail());
         if (userOpt.isPresent()) {
             User user = userOpt.get();
+
+            // 탈퇴 사용자면 deletedAt만 null로 하고 복구처리
+            if (user.getDeletedAt() != null) {
+                user.setDeletedAt(null);
+                userRepository.save(user);
+            }
 
             // RefreshToken Redis에 저장
             String refreshToken = jwtTokenProvider.createRefreshToken(user);

--- a/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java
+++ b/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java
@@ -2,10 +2,12 @@ package icet.koco.auth.service;
 
 import icet.koco.auth.dto.KakaoTokenResponse;
 import icet.koco.auth.dto.KakaoUserResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Slf4j
 @Component
 public class KakaoOAuthClient {
 
@@ -42,5 +44,30 @@ public class KakaoOAuthClient {
             .bodyToMono(KakaoUserResponse.class)
             .block();
     }
+
+    @Value("${KAKAO_ADMIN_KEY}")
+    private String adminKey;
+
+    public void unlinkUser(String kakaoUserId) {
+        try {
+            String response = WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader("Authorization", "KakaoAK " + adminKey)
+                .defaultHeader("Content-Type", "application/x-www-form-urlencoded")
+                .build()
+                .post()
+                .uri("/v1/user/unlink")
+                .bodyValue("target_id_type=user_id&target_id=" + kakaoUserId)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+            log.info(">>>>> 카카오 사용자 연결 끊기 성공: {}", response);
+
+        } catch (Exception e) {
+            log.warn(">>>>> 카카오 사용자 unlink 실패 - 무시하고 계속 진행: {}", e.getMessage());
+        }
+    }
 }
+
 

--- a/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java
+++ b/Koco/src/main/java/icet/koco/auth/service/KakaoOAuthClient.java
@@ -2,6 +2,7 @@ package icet.koco.auth.service;
 
 import icet.koco.auth.dto.KakaoTokenResponse;
 import icet.koco.auth.dto.KakaoUserResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -9,7 +10,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class KakaoOAuthClient {
+
+    private final WebClient kakaoWebClient; // WebClient 주입
 
     @Value("${KAKAO_CLIENT_ID}")
     private String clientId;
@@ -20,13 +24,8 @@ public class KakaoOAuthClient {
     @Value("${KAKAO_REDIRECT_URI}")
     private String redirectUri;
 
-    private final WebClient webClient = WebClient.create();
-
     public KakaoUserResponse getUserInfo(String code) {
-        System.out.println("받은 인가코드: " + code);
-        System.out.println("clientId: " + clientId);
-        System.out.println("redirectUri: " + redirectUri);
-        String token = webClient.post()
+        String token = kakaoWebClient.post()
             .uri("https://kauth.kakao.com/oauth/token")
             .header("Content-Type", "application/x-www-form-urlencoded")
             .bodyValue("grant_type=authorization_code&client_id=" + clientId +
@@ -37,7 +36,7 @@ public class KakaoOAuthClient {
             .block()
             .getAccess_token();
 
-        return webClient.get()
+        return kakaoWebClient.get()
             .uri("https://kapi.kakao.com/v2/user/me")
             .header("Authorization", "Bearer " + token)
             .retrieve()
@@ -45,29 +44,19 @@ public class KakaoOAuthClient {
             .block();
     }
 
-    @Value("${KAKAO_ADMIN_KEY}")
-    private String adminKey;
-
     public void unlinkUser(String kakaoUserId) {
         try {
-            String response = WebClient.builder()
-                .baseUrl("https://kapi.kakao.com")
-                .defaultHeader("Authorization", "KakaoAK " + adminKey)
-                .defaultHeader("Content-Type", "application/x-www-form-urlencoded")
-                .build()
-                .post()
+            String response = kakaoWebClient.post()
                 .uri("/v1/user/unlink")
                 .bodyValue("target_id_type=user_id&target_id=" + kakaoUserId)
                 .retrieve()
                 .bodyToMono(String.class)
                 .block();
 
-            log.info(">>>>> 카카오 사용자 연결 끊기 성공: {}", response);
-
+            log.info(">>>>> Kakao 사용자 연결 끊기 성공: {}", response);
         } catch (Exception e) {
-            log.warn(">>>>> 카카오 사용자 unlink 실패 - 무시하고 계속 진행: {}", e.getMessage());
+            log.warn(">>>>> Kakao unlink 실패: {}", e.getMessage());
+
         }
     }
 }
-
-

--- a/Koco/src/main/java/icet/koco/auth/service/LogoutService.java
+++ b/Koco/src/main/java/icet/koco/auth/service/LogoutService.java
@@ -3,6 +3,7 @@ package icet.koco.auth.service;
 import icet.koco.auth.dto.LogoutResponse;
 import icet.koco.auth.repository.OAuthRepository;
 import icet.koco.global.exception.UnauthorizedException;
+import icet.koco.util.CookieUtil;
 import icet.koco.util.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,6 +19,7 @@ public class LogoutService {
     private final OAuthRepository oauthRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
+    private final CookieUtil cookieUtil;
 
     public LogoutResponse logout(HttpServletRequest request, HttpServletResponse response) {
         // 1. 쿠키에서 accessToken 추출
@@ -49,8 +51,8 @@ public class LogoutService {
         redisTemplate.opsForValue().set("BL:" + accessToken, "logout", expiration, java.util.concurrent.TimeUnit.MILLISECONDS);
 
         // 6. 쿠키 제거
-        invalidateAccessTokenCookie(response);
-        invalidateRefreshTokenCookie(response);
+        cookieUtil.invalidateCookie(response, "access_token");
+        cookieUtil.invalidateCookie(response, "refresh_token");
 
         // 7. 응답 반환
         return LogoutResponse.builder()
@@ -68,23 +70,5 @@ public class LogoutService {
             }
         }
         return null;
-    }
-
-    private void invalidateAccessTokenCookie(HttpServletResponse response) {
-        System.out.println(">>>>> invalidateAccessTokenCookie");
-        Cookie cookie = new Cookie("access_token", null);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
-    }
-
-    private void invalidateRefreshTokenCookie(HttpServletResponse response) {
-        System.out.println(">>>>> invalidateRefreshTokenCookie");
-        Cookie cookie = new Cookie("refresh_token", null);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
     }
 }

--- a/Koco/src/main/java/icet/koco/config/SecurityConfig.java
+++ b/Koco/src/main/java/icet/koco/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package icet.koco.config;
 
 import icet.koco.util.JwtAuthenticationFilter;
 import icet.koco.util.JwtTokenProvider;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -10,6 +11,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -19,7 +23,9 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http,
         JwtTokenProvider jwtTokenProvider,
         RedisTemplate<String, String> redisTemplate) throws Exception {
+
         http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))  // CORS 설정 추가
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
@@ -30,6 +36,19 @@ public class SecurityConfig {
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:5173")); // 프론트 주소
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true); // 쿠키 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
 

--- a/Koco/src/main/java/icet/koco/config/WebClientConfig.java
+++ b/Koco/src/main/java/icet/koco/config/WebClientConfig.java
@@ -1,0 +1,24 @@
+package icet.koco.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${KAKAO_ADMIN_KEY}")
+    private String adminKey;
+
+    @Bean
+    public WebClient kakaoWebClient() {
+        return WebClient.builder()
+            .baseUrl("https://kapi.kakao.com")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + adminKey)
+            .build();
+    }
+}

--- a/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
@@ -24,6 +24,7 @@ public class SurveyController {
         @RequestBody ProblemSetSurveyRequestDto requestDto
     ) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println(">>>>> Controller userId: " + userId);
         SurveyResponseDto response = surveyService.submitSurvey(userId, requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
@@ -21,8 +21,7 @@ public class SurveyController {
 
     @PostMapping
     public ResponseEntity<SurveyResponseDto> submitSurvey(
-        @RequestBody ProblemSetSurveyRequestDto requestDto
-    ) {
+        @RequestBody ProblemSetSurveyRequestDto requestDto) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         System.out.println(">>>>> Controller userId: " + userId);
         SurveyResponseDto response = surveyService.submitSurvey(userId, requestDto);

--- a/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
@@ -63,3 +63,4 @@ public class ProblemSetService {
             .build();
     }
 }
+

--- a/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
@@ -16,9 +16,10 @@ import icet.koco.problemSet.repository.SurveyRepository;
 import icet.koco.user.entity.User;
 import icet.koco.user.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,55 +39,51 @@ public class SurveyService {
     public SurveyResponseDto submitSurvey(Long userId, ProblemSetSurveyRequestDto requestDto) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
             .orElseThrow(() -> new UnauthorizedException("존재하지 않는 사용자입니다."));
+        log.info(">>>>> 사용자 ID: {}", userId);
 
-        Long problemSetId = requestDto.getProblemSetId();
-        ProblemSet problemSet = problemSetRepository.findById(problemSetId)
+        ProblemSet problemSet = problemSetRepository.findById(requestDto.getProblemSetId())
             .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 문제집입니다."));
-
-        Set<Long> requestProblemIds = requestDto.getResponses().stream()
-            .map(ProblemSurveyRequestDto::getProblemId)
-            .collect(Collectors.toSet());
-
-        Map<Long, Problem> problemMap = problemRepository.findAllById(requestProblemIds).stream()
-            .collect(Collectors.toMap(Problem::getId, p -> p));
-
-        // 포함된 문제 ID만 조회 (JPQL 기반)
-        List<Long> includedIds = problemSetProblemRepository
-            .findIncludedProblemIds(problemSetId, new ArrayList<>(requestProblemIds));
-        Set<Long> includedProblemIds = new HashSet<>(includedIds);
+        log.info(">>>>> 문제집 번호: {}", problemSet.getId());
 
         List<Survey> surveysToSave = new ArrayList<>();
 
         for (ProblemSurveyRequestDto response : requestDto.getResponses()) {
-            Long pid = response.getProblemId();
+            Problem problem = problemRepository.findById(response.getProblemId())
+                .orElseThrow(() -> new ResourceNotFoundException(">>>>> 문제 ID " + response.getProblemId() + "가 존재하지 않습니다."));
 
-            Problem problem = problemMap.get(pid);
-            if (problem == null) {
-                throw new ResourceNotFoundException("문제 ID " + pid + "가 존재하지 않습니다.");
+            // 문제 Id가 해당 ProblemSet에 있는지 검증
+            boolean exists = problemSetProblemRepository.existsByProblemSetIdAndProblemId(problemSet.getId(), problem.getId());
+            if (!exists) {
+                throw new UnauthorizedException("문제 ID " + problem.getId() + "는 문제집 " + problemSet.getId() + "에 포함되어 있지 않습니다.");
             }
-            if (!includedProblemIds.contains(pid)) {
-                throw new UnauthorizedException("문제 ID " + pid + "는 문제집 " + problemSetId + "에 포함되어 있지 않습니다.");
-            }
+
+            log.info(">>>>> 문제 번호: {}", problem.getId());
 
             Survey survey = Survey.builder()
                 .user(user)
                 .problemSet(problemSet)
                 .problem(problem)
                 .isSolved(response.isSolved())
-                .difficultyLevel(DifficultyLevel.valueOf(response.getDifficultyLevel().toUpperCase()))
+                .difficultyLevel(DifficultyLevel.valueOf(response.getDifficultyLevel()))
                 .answeredAt(LocalDateTime.now())
                 .build();
 
             surveysToSave.add(survey);
         }
 
-        List<Survey> saved = surveyRepository.saveAll(surveysToSave);
-        List<Long> ids = saved.stream().map(Survey::getId).toList();
+        // 디비에 넣기 한 번에 수행
+        List<Survey> savedSurveys = surveyRepository.saveAll(surveysToSave);
+
+        List<Long> savedIds = savedSurveys.stream()
+            .map(Survey::getId)
+            .toList();
+
+        log.info(">>>>> 저장된 설문 ID 목록: {}", savedIds);
 
         return SurveyResponseDto.builder()
             .code("SURVEY_CREATED")
             .message("출제 문제집에 대한 설문응답이 성공적으로 생성되었습니다.")
-            .data(Map.of("surveyId", ids))
+            .data(Map.of("surveyId", savedIds))
             .build();
     }
 }

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -4,8 +4,10 @@ import icet.koco.global.dto.ApiResponse;
 import icet.koco.global.exception.UnauthorizedException;
 import icet.koco.user.service.UserService;
 import icet.koco.util.JwtTokenProvider;
+import icet.koco.util.TokenExtractor;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -22,13 +24,21 @@ public class UserController {
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenExtractor tokenExtractor;
 
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<?>> deleteUser() {
-        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        System.out.println(">>>>> Controller userId: " + userId);
+    public ResponseEntity<ApiResponse<?>> deleteUser(HttpServletRequest request, HttpServletResponse response) {
+        String token = tokenExtractor.extractFromCookies(request, "access_token");
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            throw new UnauthorizedException("유효하지 않거나 만료된 토큰입니다.");
+        }
 
-        userService.deleteUser(userId);
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        userService.deleteUser(userId, response);
+
         return ResponseEntity.noContent().build();
     }
+
+
+
 }

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -31,5 +31,4 @@ public class UserController {
         userService.deleteUser(userId);
         return ResponseEntity.noContent().build();
     }
-ㄴ
 }

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -24,31 +24,12 @@ public class UserController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<?>> deleteUser(HttpServletRequest request) {
-        String token = extractTokenFromCookies(request, "access_token");
-        if (token == null || !jwtTokenProvider.validateToken(token)) {
-            throw new UnauthorizedException("유효하지 않거나 만료된 토큰입니다.");
-        }
+    public ResponseEntity<ApiResponse<?>> deleteUser() {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println(">>>>> Controller userId: " + userId);
 
-        Long userId = jwtTokenProvider.getUserIdFromToken(token);
         userService.deleteUser(userId);
-
         return ResponseEntity.noContent().build();
     }
-
-    @GetMapping("/test/user-id")
-    public ResponseEntity<?> testUserId() {
-        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return ResponseEntity.ok("UserId: " + userId);
-    }
-
-    private String extractTokenFromCookies(HttpServletRequest request, String name) {
-        if (request.getCookies() == null) return null;
-        for (Cookie cookie : request.getCookies()) {
-            if (name.equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
-        return null;
-    }
+ㄴ
 }

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -1,0 +1,54 @@
+package icet.koco.user.controller;
+
+import icet.koco.global.dto.ApiResponse;
+import icet.koco.global.exception.UnauthorizedException;
+import icet.koco.user.service.UserService;
+import icet.koco.util.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<?>> deleteUser(HttpServletRequest request) {
+        String token = extractTokenFromCookies(request, "access_token");
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            throw new UnauthorizedException("유효하지 않거나 만료된 토큰입니다.");
+        }
+
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        userService.deleteUser(userId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/test/user-id")
+    public ResponseEntity<?> testUserId() {
+        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return ResponseEntity.ok("UserId: " + userId);
+    }
+
+    private String extractTokenFromCookies(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/Koco/src/main/java/icet/koco/user/repository/UserRepository.java
+++ b/Koco/src/main/java/icet/koco/user/repository/UserRepository.java
@@ -29,3 +29,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllByDeletedAtIsNullOrderByNicknameAsc();
 
 }
+

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -1,0 +1,55 @@
+package icet.koco.user.service;
+
+import icet.koco.auth.entity.OAuth;
+import icet.koco.auth.repository.OAuthRepository;
+import icet.koco.auth.service.KakaoOAuthClient;
+import icet.koco.global.exception.ResourceNotFoundException;
+import icet.koco.global.exception.UnauthorizedException;
+import icet.koco.user.entity.User;
+import icet.koco.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final OAuthRepository oAuthRepository;
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ResourceNotFoundException("해당 유저 정보를 찾을 수 없습니다."));
+
+        // 2. OAuth 정보 조회 (OAuth 테이블에서 userId로 조회)
+        OAuth oauth = oAuthRepository.findByUserId(userId)
+            .orElseThrow(() -> new UnauthorizedException("OAuth 정보가 존재하지 않습니다."));
+
+
+        // 3. Kakao unlink 호출 (예외 무시)
+        try {
+            kakaoOAuthClient.unlinkUser(oauth.getProviderId()); // Long 또는 String
+        } catch (Exception e) {
+            log.warn("Kakao unlink 실패 - 무시하고 계속 진행", e);
+
+        }
+        // Redis refreshToken 삭제
+        redisTemplate.delete(userId.toString());
+
+        // soft delete 처리
+        user.setDeletedAt(LocalDateTime.now());
+
+        // user에 정보 저장
+        userRepository.save(user);
+    }
+
+}
+

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -38,13 +38,12 @@ public class UserService {
         try {
             kakaoOAuthClient.unlinkUser(oauth.getProviderId()); // Long 또는 String
         } catch (Exception e) {
-            log.warn("Kakao unlink 실패 - 무시하고 계속 진행", e);
-
+            log.warn(">>>>> Kakao unlink 실패: {}", e.getMessage());
         }
         // Redis refreshToken 삭제
         redisTemplate.delete(userId.toString());
 
-        // soft delete 처리
+        // soft delete 처리 (삭제요구한 일시)
         user.setDeletedAt(LocalDateTime.now());
 
         // user에 정보 저장

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -7,6 +7,8 @@ import icet.koco.global.exception.ResourceNotFoundException;
 import icet.koco.global.exception.UnauthorizedException;
 import icet.koco.user.entity.User;
 import icet.koco.user.repository.UserRepository;
+import icet.koco.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,33 +24,35 @@ public class UserService {
     private final KakaoOAuthClient kakaoOAuthClient;
     private final RedisTemplate<String, String> redisTemplate;
     private final OAuthRepository oAuthRepository;
+    private final CookieUtil cookieUtil;
 
     @Transactional
-    public void deleteUser(Long userId) {
+    public void deleteUser(Long userId, HttpServletResponse response) {
         // 1. 유저 조회
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new ResourceNotFoundException("해당 유저 정보를 찾을 수 없습니다."));
 
-        // 2. OAuth 정보 조회 (OAuth 테이블에서 userId로 조회)
+        // 2. OAuth 정보 조회
         OAuth oauth = oAuthRepository.findByUserId(userId)
             .orElseThrow(() -> new UnauthorizedException("OAuth 정보가 존재하지 않습니다."));
 
-
-        // 3. Kakao unlink 호출 (예외 무시)
+        // 3. Kakao unlink 호출
         try {
-            kakaoOAuthClient.unlinkUser(oauth.getProviderId()); // Long 또는 String
+            kakaoOAuthClient.unlinkUser(oauth.getProviderId());
         } catch (Exception e) {
             log.warn(">>>>> Kakao unlink 실패: {}", e.getMessage());
         }
-        // Redis refreshToken 삭제
+
+        // 4. Redis refreshToken 삭제
         redisTemplate.delete(userId.toString());
 
-        // soft delete 처리 (삭제요구한 일시)
+        // 5. Soft delete 처리
         user.setDeletedAt(LocalDateTime.now());
-
-        // user에 정보 저장
         userRepository.save(user);
-    }
 
+        // 6. 쿠키 삭제 처리
+        cookieUtil.invalidateCookie(response, "access_token");
+        cookieUtil.invalidateCookie(response, "refresh_token");
+    }
 }
 

--- a/Koco/src/main/java/icet/koco/util/CookieUtil.java
+++ b/Koco/src/main/java/icet/koco/util/CookieUtil.java
@@ -1,0 +1,17 @@
+package icet.koco.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public void invalidateCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(cookie);
+    }
+}

--- a/Koco/src/main/java/icet/koco/util/TokenExtractor.java
+++ b/Koco/src/main/java/icet/koco/util/TokenExtractor.java
@@ -1,0 +1,18 @@
+package icet.koco.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenExtractor {
+    public String extractFromCookies(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 📝 개요
- Kakao 소셜 로그인을 사용하는 사용자의 탈퇴 기능을 구현
- 추후에 복구 / 접근할 수 있도록 SoftDelete로 구현하면서 Kakao와 Unlink를 수행

## 🔗 연관된 이슈
- #12 

## 🔄 변경사항 및 이유
- `UserService.deleteUser()` 메서드 추가
→ 사용자를 `deletedAt` 기준으로 soft delete 처리
- `OAuthRepository.findByUserId()` 사용
→ Kakao 사용자 unlink 처리를 위해 OAuth 정보 조회

- `KakaoOAuthClient.unlinkUser()` 로직 개선
→ WebClient를 통한 unlink API 호출 구현

- `UserController`에 `DELETE /api/v1/users/me` 엔드포인트 추가
→ 로그인된 사용자 쿠키 기반 토큰을 검증 후 탈퇴 처리 수행

- `WebClientConfig` 클래스 추가
→ Kakao API 호출용 WebClient Bean 등록으로 성능 및 재사용성 개선

## 📋 작업할 내용
- [ ] Controller 엔드포인트 생성
- [ ] JWT에서 사용자 ID 추출
- [ ] 사용자 존재 여부 확인
- [ ] 탈퇴 처리 (soft delete)
- [ ] 204 상태 코드 응답 처리


## 🔖 기타사항
- 사용자 탈퇴 후 재가입 시 '신규 가입자' 처리가 아니라 '**복구**'하는 방식으로 구현하였습니다.

## 👀 리뷰 요구사항
- Kakao OAuth 2.0 로직이 구현한 코드와 맞는지 확인 부탁드립니다.
- `KakaoOAuthClient.unlinkUser()`의 WebClient 설정 방식이 적절한지 확인 부탁드립니다.
