### PR TITLE
[Feat] 문제 해설 조회 기능 API 구현 (#10)

### DIFF
--- a/Koco/src/main/java/icet/koco/problemSet/controller/ProblemSetController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/ProblemSetController.java
@@ -1,14 +1,18 @@
 package icet.koco.problemSet.controller;
 
 import icet.koco.global.dto.ApiResponse;
+import icet.koco.global.exception.UnauthorizedException;
 import icet.koco.problemSet.dto.ProblemSetResponseDto;
+import icet.koco.problemSet.dto.ProblemSolutionResponseDto;
 import icet.koco.problemSet.service.ProblemSetService;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +32,19 @@ public class ProblemSetController {
         ProblemSetResponseDto response = problemSetService.getProblemSetByDate(userId, date);
         return ResponseEntity.ok(
             ApiResponse.success("PROBLEM_SET_FETCH_SUCCESS", "문제 리스트 조회 성공", response)
+        );
+    }
+
+    @GetMapping("/{problemNumber}/solution")
+    public ResponseEntity<?> getProblemSolution(@PathVariable Long problemNumber) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthorizedException("로그인이 필요합니다.");
+        }
+
+        ProblemSolutionResponseDto dto = problemSetService.getProblemSolution(problemNumber);
+        return ResponseEntity.ok(
+            ApiResponse.success("PROBLEM_SOLUTION_SUCCESS", "문제 해설 조회 성공", dto)
         );
     }
 }

--- a/Koco/src/main/java/icet/koco/problemSet/controller/SolutionController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/SolutionController.java
@@ -1,0 +1,34 @@
+package icet.koco.problemSet.controller;
+
+
+import icet.koco.problemSet.dto.AiSolutionRequestDto;
+import icet.koco.problemSet.service.SolutionService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/solution")
+@RequiredArgsConstructor
+public class SolutionController {
+
+    private final SolutionService solutionService;
+
+    @PostMapping
+    public ResponseEntity<?> receiveSolution(@RequestBody AiSolutionRequestDto dto) {
+        solutionService.saveFromAi(dto);
+        return ResponseEntity.ok(new ApiResponse("SOLUTION_RECEIVED", "해설 저장 완료"));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class ApiResponse {
+        private String code;
+        private String message;
+    }
+}

--- a/Koco/src/main/java/icet/koco/problemSet/dto/AiSolutionRequestDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/AiSolutionRequestDto.java
@@ -1,0 +1,24 @@
+package icet.koco.problemSet.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AiSolutionRequestDto {
+    private Long problemNumber;
+    private ProblemCheck problem_check;
+    private String problem_solving;
+    private SolutionCode solution_code;
+
+    @Getter
+    public static class ProblemCheck {
+        private String problem_description;
+        private String algorithm;
+    }
+
+    @Getter
+    public static class SolutionCode {
+        private String python;
+        private String cpp;
+        private String java;
+    }
+}

--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSolutionResponseDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSolutionResponseDto.java
@@ -1,0 +1,28 @@
+package icet.koco.problemSet.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.Map;
+
+@Getter
+@Builder
+public class ProblemSolutionResponseDto {
+    private Long problemNumber;
+    private String tier;
+    private String title;
+    private Integer timeLimit;
+    private Integer memoryLimit;
+    private Integer submissionCnt;
+    private Integer answerCnt;
+    private Integer correctPplCnt;
+    private Double correctRate;
+    private String description;
+    private String inputDescription;
+    private String outputDescription;
+    private String inputExample;
+    private String outputExample;
+    private String problemCheck;
+    private String algorithm;
+    private String problemSolving;
+    private Map<String, String> solutionCode;
+}

--- a/Koco/src/main/java/icet/koco/problemSet/repository/ProblemRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/ProblemRepository.java
@@ -3,7 +3,12 @@ package icet.koco.problemSet.repository;
 import icet.koco.problemSet.entity.Problem;
 import icet.koco.problemSet.entity.ProblemSet;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
+
+    // 백준 문제 번호로
+    Optional<Problem> findByNumber(Long Number);
+
 }

--- a/Koco/src/main/java/icet/koco/problemSet/repository/SolutionRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/SolutionRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SolutionRepository extends JpaRepository<Solution, Long> {
-    // 문제로 조회
-    // problem Entity를 넘기면 내부에서 problem.getId()로 처리해준다고 함
-    Optional<Solution> findByProblem(Problem problem);
+    // 중복 여부 확인용
+    boolean existsByProblem(Problem problem);
 }
+

--- a/Koco/src/main/java/icet/koco/problemSet/repository/SolutionRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/SolutionRepository.java
@@ -8,5 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SolutionRepository extends JpaRepository<Solution, Long> {
     // 중복 여부 확인용
     boolean existsByProblem(Problem problem);
+
+    Optional<Solution> findByProblem(Problem problem);
+
 }
 

--- a/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
@@ -1,19 +1,24 @@
 package icet.koco.problemSet.service;
 
 import icet.koco.global.exception.ForbiddenException;
+import icet.koco.global.exception.ResourceNotFoundException;
 import icet.koco.problemSet.dto.ProblemSetResponseDto;
 import icet.koco.problemSet.dto.ProblemDto;
+import icet.koco.problemSet.dto.ProblemSolutionResponseDto;
 import icet.koco.problemSet.entity.Problem;
 import icet.koco.problemSet.entity.ProblemSet;
 import icet.koco.problemSet.entity.ProblemSetProblem;
+import icet.koco.problemSet.entity.Solution;
 import icet.koco.problemSet.repository.ProblemRepository;
 import icet.koco.problemSet.repository.ProblemSetProblemRepository;
 import icet.koco.problemSet.repository.ProblemSetRepository;
+import icet.koco.problemSet.repository.SolutionRepository;
 import icet.koco.problemSet.repository.SurveyRepository;
 import icet.koco.user.entity.User;
 import icet.koco.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProblemSetService {
 
     private final ProblemSetRepository problemSetRepository;
+    private final ProblemRepository problemRepository;
+    private final SolutionRepository solutionRepository;
     private final ProblemSetProblemRepository problemSetProblemRepository;
     private final SurveyRepository surveyRepository;
     private final UserRepository userRepository;
@@ -60,6 +67,40 @@ public class ProblemSetService {
             .problemSetId(problemSet.getId())
             .isAnswered(isAnswered)
             .problems(problemDtos)
+            .build();
+    }
+
+    @Transactional(readOnly = true)
+    public ProblemSolutionResponseDto getProblemSolution(Long problemNumber) {
+        Problem problem = problemRepository.findByNumber(problemNumber)
+            .orElseThrow(() -> new ResourceNotFoundException("해당 문제를 찾을 수 없습니다."));
+
+        Solution solution = solutionRepository.findByProblem(problem)
+            .orElseThrow(() -> new ResourceNotFoundException("해당 문제에 대한 해설이 없습니다."));
+
+        return ProblemSolutionResponseDto.builder()
+            .problemNumber(problem.getNumber())
+            .tier(problem.getTier())
+            .title(problem.getTitle())
+            .timeLimit(problem.getTimeLimit())
+            .memoryLimit(problem.getMemoryLimit())
+            .submissionCnt(problem.getSubmissionCnt())
+            .answerCnt(problem.getAnswerCnt())
+            .correctPplCnt(problem.getCorrectPplCnt())
+            .correctRate(problem.getCorrectRate())
+            .description(problem.getDescription())
+            .inputDescription(problem.getInputDescription())
+            .outputDescription(problem.getOutputDescription())
+            .inputExample(problem.getInputExample())
+            .outputExample(problem.getOutputExample())
+            .problemCheck(solution.getDescription())
+            .algorithm(solution.getAlgorithm())
+            .problemSolving(solution.getProblemSolving())
+            .solutionCode(Map.of(
+                "cpp", solution.getCodeCpp(),
+                "java", solution.getCodeJava(),
+                "python", solution.getCodePy()
+            ))
             .build();
     }
 }

--- a/Koco/src/main/java/icet/koco/problemSet/service/SolutionService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/SolutionService.java
@@ -1,0 +1,44 @@
+package icet.koco.problemSet.service;
+
+import icet.koco.problemSet.dto.AiSolutionRequestDto;
+import icet.koco.problemSet.entity.Problem;
+import icet.koco.problemSet.entity.Solution;
+import icet.koco.problemSet.repository.ProblemRepository;
+import icet.koco.problemSet.repository.SolutionRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SolutionService {
+
+    private final SolutionRepository solutionRepository;
+    private final ProblemRepository problemRepository;
+
+    public void saveFromAi(AiSolutionRequestDto dto) {
+        // 1. 백준 번호로 내부 problemId 조회
+        Problem problem = problemRepository.findByNumber(dto.getProblemNumber())
+            .orElseThrow(() -> new IllegalArgumentException(
+                "해당 문제 번호를 가진 Problem이 없습니다: " + dto.getProblemNumber()));
+
+        // 2. 문제에 대한 해설이 이미 존재하는지 확인
+        if (solutionRepository.existsByProblem(problem)) {
+            throw new IllegalArgumentException("이미 해당 문제에 대한 해설이 존재합니다.");
+        }
+
+        // 2. Solution 저장
+        Solution solution = Solution.builder()
+            .problem(problem)  // 연관관계 설정
+            .description(dto.getProblem_check().getProblem_description())
+            .algorithm(dto.getProblem_check().getAlgorithm())
+            .problemSolving(dto.getProblem_solving())
+            .codeCpp(dto.getSolution_code().getCpp())
+            .codeJava(dto.getSolution_code().getJava())
+            .codePy(dto.getSolution_code().getPython())
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        solutionRepository.save(solution);
+    }
+}


### PR DESCRIPTION
## 📝 개요
- AI 서버와 연결하는 Endpoint 생성
- 문제 해설 조회 기능 API 구현

## 🔗 연관된 이슈
- #10 

## 📋 작업한 내용
- [x] AI 서버 응답 받아오는 endpoint 설계 (solution 도메인으로 따로 분리)
- [x] 문제 해설 조회 기능 구현

## 🔖 기타사항
- AI 서버와 테스트 필요
