### PR TITLE
[Feat] 유저 대시보드 API 구현 (#13)

### DIFF
--- a/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
+++ b/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/backend/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/Koco/src/main/java/icet/koco/config/SecurityConfig.java
+++ b/Koco/src/main/java/icet/koco/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**")
+                .requestMatchers("/api/backend/v1/auth/**", "/swagger-ui/**",  "/api-docs","/v3/api-docs/**", "/swagger-resources/**", "/webjars/**")
                 .permitAll()
                 .anyRequest().authenticated()
             )

--- a/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java
+++ b/Koco/src/main/java/icet/koco/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -43,6 +44,11 @@ public class GlobalExceptionHandler {
         return buildErrorResponse("INTERNAL_SERVER_ERROR", "서버에서 에러가 발생하였습니다", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    // 파일 업로드 크기 5MB로 제한
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<String> handleMaxSizeException(MaxUploadSizeExceededException ex) {
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body("파일 크기가 제한을 초과했습니다.");
+    }
 
     // 공통 응답 생성 함수
     private ResponseEntity<ErrorResponse> buildErrorResponse(String code, String message, HttpStatus status) {

--- a/Koco/src/main/java/icet/koco/problemSet/controller/ProblemSetController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/ProblemSetController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/problem-set")
+@RequestMapping("/api/backend/v1/problem-set")
 public class ProblemSetController {
 
     private final ProblemSetService problemSetService;

--- a/Koco/src/main/java/icet/koco/problemSet/controller/SolutionController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/SolutionController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/solution")
+@RequestMapping("/api/backend/v1/solution")
 @RequiredArgsConstructor
 public class SolutionController {
 

--- a/Koco/src/main/java/icet/koco/problemSet/controller/SolutionController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/SolutionController.java
@@ -1,10 +1,9 @@
 package icet.koco.problemSet.controller;
 
 
+import icet.koco.global.dto.ApiResponse;
 import icet.koco.problemSet.dto.AiSolutionRequestDto;
 import icet.koco.problemSet.service.SolutionService;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,13 +21,6 @@ public class SolutionController {
     @PostMapping
     public ResponseEntity<?> receiveSolution(@RequestBody AiSolutionRequestDto dto) {
         solutionService.saveFromAi(dto);
-        return ResponseEntity.ok(new ApiResponse("SOLUTION_RECEIVED", "해설 저장 완료"));
-    }
-
-    @Getter
-    @AllArgsConstructor
-    static class ApiResponse {
-        private String code;
-        private String message;
+        return ResponseEntity.ok(ApiResponse.success("SOLUTION_RECEIVED", "해설 저장 완료", null));
     }
 }

--- a/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
+++ b/Koco/src/main/java/icet/koco/problemSet/controller/SurveyController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/problem-set/surveys")
+@RequestMapping("/api/backend/v1/problem-set/surveys")
 @RequiredArgsConstructor
 public class SurveyController {
 

--- a/Koco/src/main/java/icet/koco/problemSet/entity/Survey.java
+++ b/Koco/src/main/java/icet/koco/problemSet/entity/Survey.java
@@ -1,5 +1,6 @@
 package icet.koco.problemSet.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import icet.koco.enums.DifficultyLevel;
 import icet.koco.user.entity.User;
 import jakarta.persistence.*;
@@ -47,6 +48,7 @@ public class Survey {
     private Problem problem;
 
     // 해결 여부
+    @JsonProperty("isSolved")
     @Column(name = "is_solved", nullable = false)
     private boolean isSolved;
 

--- a/Koco/src/main/java/icet/koco/problemSet/repository/SurveyRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/SurveyRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface SurveyRepository extends JpaRepository<Survey, Long> {
+public interface SurveyRepository extends JpaRepository<Survey, Long>, SurveyRepositoryCustom {
 
-    // 방식 1: 설문 개수 비교
+// 방식 1: 설문 개수 비교
     long countByUserAndProblemSet(User user, ProblemSet problemSet);
 
     // 방식 2: 설문 작성된 문제 ID 목록 조회

--- a/Koco/src/main/java/icet/koco/problemSet/repository/SurveyRepositoryCustom.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/SurveyRepositoryCustom.java
@@ -1,0 +1,8 @@
+package icet.koco.problemSet.repository;
+
+import icet.koco.user.dto.UserCategoryStatProjection;
+import java.util.List;
+
+public interface SurveyRepositoryCustom {
+    List<UserCategoryStatProjection> calculateCorrectRateByCategory(Long userId);
+}

--- a/Koco/src/main/java/icet/koco/problemSet/repository/impl/SurveyRepositoryImpl.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/impl/SurveyRepositoryImpl.java
@@ -1,0 +1,33 @@
+package icet.koco.problemSet.repository.impl;
+
+
+import icet.koco.problemSet.repository.SurveyRepositoryCustom;
+import icet.koco.user.dto.UserCategoryStatProjection;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SurveyRepositoryImpl implements SurveyRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public List<UserCategoryStatProjection> calculateCorrectRateByCategory(Long userId) {
+        return em.createQuery("""
+        SELECT new icet.koco.user.dto.UserCategoryStatDto(
+            pc.category.id,
+            pc.category.name,
+            (SUM(CASE WHEN s.isSolved = true THEN 1 ELSE 0 END) * 1.0) / COUNT(s)
+        )
+        FROM Survey s
+        JOIN ProblemCategory pc ON s.problem.id = pc.problem.id
+        WHERE s.user.id = :userId
+        GROUP BY pc.category.id, pc.category.name
+        ORDER BY ((SUM(CASE WHEN s.isSolved = true THEN 1 ELSE 0 END) * 1.0) / COUNT(s)) DESC
+        """, UserCategoryStatProjection.class)
+            .setParameter("userId", userId)
+            .getResultList();
+    }
+
+}

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package icet.koco.user.controller;
 
 import icet.koco.global.dto.ApiResponse;
+import icet.koco.global.dto.ErrorResponse;
 import icet.koco.global.exception.UnauthorizedException;
+import icet.koco.user.dto.DashboardResponseDto;
 import icet.koco.user.dto.UserResponse;
 import icet.koco.user.service.UserService;
 import icet.koco.user.service.uploader.ImageUploader;
@@ -10,20 +12,26 @@ import icet.koco.util.TokenExtractor;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -53,4 +61,22 @@ public class UserController {
 
         return ResponseEntity.ok(UserResponse.ofSuccess());
     }
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<?> getDashboard(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        try {
+            System.out.println(">>>> dashboard API 진입");
+            Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            System.out.println(">>> principal: " + principal + " / class: " + principal.getClass().getName());
+
+            Long userId = Long.valueOf(principal.toString());
+            DashboardResponseDto response = userService.getUserDashboard(userId, date);
+            return ResponseEntity.ok(ApiResponse.success("USER_DASHBOARD_GET_SUCCESS", "유저 프로필 정보 조회 성공", response));
+        } catch (Exception e) {
+            log.error("대시보드 API 에러 발생", e);
+            e.printStackTrace(); // 콘솔에 전체 에러 출력
+            return ResponseEntity.internalServerError().body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "셔벼 내부 에러"));
+        }
+    }
+
 }

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -33,7 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/backend/v1/users")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -65,9 +65,7 @@ public class UserController {
     @GetMapping("/dashboard")
     public ResponseEntity<?> getDashboard(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         try {
-            System.out.println(">>>> dashboard API 진입");
             Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-            System.out.println(">>> principal: " + principal + " / class: " + principal.getClass().getName());
 
             Long userId = Long.valueOf(principal.toString());
             DashboardResponseDto response = userService.getUserDashboard(userId, date);

--- a/Koco/src/main/java/icet/koco/user/dto/DashboardResponseDto.java
+++ b/Koco/src/main/java/icet/koco/user/dto/DashboardResponseDto.java
@@ -1,0 +1,24 @@
+package icet.koco.user.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DashboardResponseDto {
+    private Long userId;
+    private String nickname;
+    private String statusMessage;
+    private String profileImgUrl;
+    private Long todayProblemSetId;
+    private List<CategoryStat> studyStats;
+
+    @Getter
+    @Builder
+    public static class CategoryStat {
+        private Long categoryId;
+        private String categoryName;
+        private Double correctRate;
+    }
+}

--- a/Koco/src/main/java/icet/koco/user/dto/UserCategoryStatDto.java
+++ b/Koco/src/main/java/icet/koco/user/dto/UserCategoryStatDto.java
@@ -1,0 +1,27 @@
+package icet.koco.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserCategoryStatDto implements UserCategoryStatProjection {
+    private Long categoryId;
+    private String categoryName;
+    private Double correctRate;
+
+    @Override
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    @Override
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    @Override
+    public Double getCorrectRate() {
+        return correctRate;
+    }
+}

--- a/Koco/src/main/java/icet/koco/user/dto/UserCategoryStatProjection.java
+++ b/Koco/src/main/java/icet/koco/user/dto/UserCategoryStatProjection.java
@@ -1,0 +1,7 @@
+package icet.koco.user.dto;
+
+public interface UserCategoryStatProjection {
+    Long getCategoryId();
+    String getCategoryName();
+    Double getCorrectRate();
+}

--- a/Koco/src/main/java/icet/koco/user/entity/UserAlgorithmStats.java
+++ b/Koco/src/main/java/icet/koco/user/entity/UserAlgorithmStats.java
@@ -6,7 +6,10 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "user_algorithm_stats")
+@Table(
+    name = "user_algorithm_stats",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "category_id"})
+)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/Koco/src/main/java/icet/koco/user/entity/UserDetail.java
+++ b/Koco/src/main/java/icet/koco/user/entity/UserDetail.java
@@ -25,31 +25,31 @@ public class UserDetail {
 
     // 군집
     @ManyToOne (fetch = FetchType.LAZY)
-    @JoinColumn(name = "cluster_id", nullable = false)
+    @JoinColumn(name = "cluster_id")
     private Cluster cluster;
 
     // 군집에 등록된 날짜
-    @Column(name = "cluster_time", nullable = false)
+    @Column(name = "cluster_time")
     private LocalDateTime clusterTime;
 
     // 맞은 문제 개수
-    @Column(name = "correct_cnt", nullable = false)
+    @Column(name = "correct_cnt")
     private Integer correctCnt;
 
     // 응답 설문 개수
-    @Column(name = "survey_cnt", nullable = false)
+    @Column(name = "survey_cnt")
     private Integer surveyCnt;
 
     // 평균 난이도
-    @Column(name = "difficulty_avg", nullable = false, columnDefinition = "DECIMAL(4,1)")
+    @Column(name = "difficulty_avg", columnDefinition = "DECIMAL(4,1)")
     private Double difficultyAvg;
 
     // 맞춘 비율
-    @Column(name = "correct_rate", nullable = false, columnDefinition = "DECIMAL(4, 1)")
+    @Column(name = "correct_rate", columnDefinition = "DECIMAL(4, 1)")
     private Double correctRate;
 
     // 응답 비율
-    @Column(name = "response_rate", nullable = false, columnDefinition = "DECIMAL(4, 1)")
+    @Column(name = "response_rate", columnDefinition = "DECIMAL(4, 1)")
     private Double responseRate;
 
     // 갱신일자

--- a/Koco/src/main/java/icet/koco/user/repository/UserAlgorithmStatsRepository.java
+++ b/Koco/src/main/java/icet/koco/user/repository/UserAlgorithmStatsRepository.java
@@ -13,5 +13,7 @@ public interface UserAlgorithmStatsRepository extends JpaRepository<UserAlgorith
     List<UserAlgorithmStats> findByUser(User user);
 
     // 특정 사용자 + 카테고리 통계 조회
+    Optional<UserAlgorithmStats> findByUserIdAndCategoryId(Long userId, Long categoryId);
+
     Optional<UserAlgorithmStats> findByUserAndCategory(User user, Category category);
 }

--- a/Koco/src/main/java/icet/koco/user/repository/UserRepository.java
+++ b/Koco/src/main/java/icet/koco/user/repository/UserRepository.java
@@ -16,6 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일으로 유저 조회
     Optional<User> findByEmail(String email);
 
+    Optional<User> findById(Long id);
+
     // ID로 조회하면서 soft delete 제외
     Optional<User> findByIdAndDeletedAtIsNull(Long id);
 

--- a/Koco/src/main/java/icet/koco/user/service/UserAlgorithmStatsService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserAlgorithmStatsService.java
@@ -1,0 +1,44 @@
+package icet.koco.user.service;
+
+import icet.koco.problemSet.entity.Category;
+import icet.koco.problemSet.repository.CategoryRepository;
+import icet.koco.user.entity.User;
+import icet.koco.user.entity.UserAlgorithmStats;
+import icet.koco.user.repository.UserAlgorithmStatsRepository;
+import icet.koco.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAlgorithmStatsService {
+
+    private final UserAlgorithmStatsRepository statsRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public void upsertCorrectRate(Long userId, Long categoryId, Double correctRate) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+
+        Category category = categoryRepository.findById(categoryId)
+            .orElseThrow(() -> new IllegalArgumentException("Category not found with id: " + categoryId));
+
+        Optional<UserAlgorithmStats> existing = statsRepository.findByUserAndCategory(user, category);
+
+        if (existing.isPresent()) {
+            UserAlgorithmStats stats = existing.get();
+            stats.setCorrectRate(correctRate.intValue());
+        } else {
+            UserAlgorithmStats newStats = UserAlgorithmStats.builder()
+                .user(user)
+                .category(category)
+                .correctRate(correctRate.intValue())
+                .build();
+            statsRepository.save(newStats);
+        }
+    }
+}

--- a/Koco/src/main/resources/application.properties
+++ b/Koco/src/main/resources/application.properties
@@ -15,5 +15,8 @@ cloud.aws.credentials.secret-key=${AWS_S3_SECRET_KEY}
 
 cloud.aws.region.static=${AWS_REGION_STATIC}
 cloud.aws.s3.bucket=aposfiij
-
 cloud.aws.stack.auto=false
+
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB


### PR DESCRIPTION
## 📝 개요
- 메인페이지에서 보이는 대시보드 조회 API를 구현함


## 🔗 연관된 이슈
- #13 

## 🔄 변경사항 및 이유
- 오늘 날짜에 해당하는 `problemSet` 에 대한 설문 페이지로 바로 갈 수 있도록 날짜를 쿼리 파라미터로 받음
  - 만약 해당 `problemSet`이 없으면 `TodayProblemSet`은 null 반환
- `ProblemSetProblemRepository`에서 `ProblemSetId`로 문제 목록을 조회하도록 메서드 추가
- `UserAlgorithmStatsRepository`에서 상위 5개 정답률 카테고리 조회 쿼리 작성

## 🔖 기타사항
- [ ] MVP 용으로 대시보드 조회 시 `UserAlgorithmStats` DB에 저장되고 -> 조회까지 되는 로직으로 구현함
- [ ] 추후 설문 완료 시 `UserAlgorithmStats` 관련된 DB 저장이 되도록 수정 필요 (대시보드 조회 시: MVP-> 쿼리 조회 || 고도화 -> Redis 캐싱)

## ✅ 확인사항
- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 스타일 가이드에 맞게 작성
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음
