### PR TITLE
[Chore] WebClient BaseUrl 변경 (#22)

### DIFF
--- a/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml
+++ b/.idea/dataSources/b53a4fef-5b2d-4b59-9404-b62a8acb23ae.xml
@@ -1744,7 +1744,6 @@ problem_id</ColNames>
       <StoredType>varchar(10)|0s</StoredType>
     </column>
     <column id="442" parent="310" name="nickname">
-      <NotNull>1</NotNull>
       <Position>6</Position>
       <StoredType>varchar(15)|0s</StoredType>
     </column>

--- a/Koco/src/main/java/icet/koco/config/WebClientConfig.java
+++ b/Koco/src/main/java/icet/koco/config/WebClientConfig.java
@@ -13,8 +13,18 @@ public class WebClientConfig {
     @Value("${KAKAO_ADMIN_KEY}")
     private String adminKey;
 
+    // OAuth 인증용 (토큰 발급용)
     @Bean
-    public WebClient kakaoWebClient() {
+    public WebClient kakaoAuthClient() {
+        return WebClient.builder()
+            .baseUrl("https://kauth.kakao.com")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .build();
+    }
+
+    // 사용자 API 호출용
+    @Bean
+    public WebClient kakaoApiClient() {
         return WebClient.builder()
             .baseUrl("https://kapi.kakao.com")
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)


### PR DESCRIPTION
## 📝 개요
- WebClient BaseUrl 변경

## 🔗 연관된 이슈
- #22 
## 🔄 변경사항 및 이유
- redirectUrl 불일치 확인하니 baseUrl로 타 url이 들어가 있어 변경함

## 📋 작업할 내용
- [x] 토큰 발급용 `kakaoAuthClient`
- [x] API 호출용 `kakaoApiClient`
