### PR TITLE
[Chore] 401 에러 추가 (#31)

### DIFF
--- a/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
+++ b/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
@@ -3,9 +3,11 @@ package icet.koco.auth.controller;
 import icet.koco.auth.dto.*;
 import icet.koco.auth.service.AuthService;
 import icet.koco.auth.service.LogoutService;
+import icet.koco.global.exception.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,7 +21,7 @@ public class AuthController {
 
     @GetMapping("/callback")
     public ResponseEntity<AuthResponse> kakaoCallback(@RequestParam("code") String code,
-        HttpServletResponse response) {
+                                                      HttpServletResponse response) {
         System.out.println("인가코드: " + code);
         AuthResponse authResponse = authService.loginWithKakao(code, response);
         return ResponseEntity.ok(authResponse);
@@ -32,11 +34,14 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<RefreshResponse> refreshToken(
-        @CookieValue(value = "refresh_token", required = true) String refreshToken,
-        HttpServletResponse response)
-    {
-        System.out.println("refresh_token: " + refreshToken);
-        RefreshResponse refreshResponse = authService.refreshAccessToken(refreshToken, response);
-        return ResponseEntity.ok(refreshResponse);
+            @CookieValue(value = "refresh_token", required = true) String refreshToken,
+            HttpServletResponse response) {
+        try {
+            System.out.println("refresh_token: " + refreshToken);
+            RefreshResponse refreshResponse = authService.refreshAccessToken(refreshToken, response);
+            return ResponseEntity.ok(refreshResponse);
+        } catch (UnauthorizedException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
     }
 }


### PR DESCRIPTION
## 📝 개요
- refresh_token 만료 시 401 Error

## 🔗 연관된 이슈
- #31 

## 🔄 변경사항 및 이유
- Unauthorized로 변경

## 📋 작업할 내용
- [x] try-catch 문 내부에 에러 