### PR TITLE
[Enhancement] 대시보드 조회 API 분리 (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/workspace.xml
+/.idea
+/.github/ISSUE_TEMPLATE
+/.idea

--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemDto.java
@@ -11,6 +11,7 @@ public class ProblemDto {
     private Long problemId;      // 서비스 내부 문제 ID
     private String title;
     private String tier;
+    private String bojUrl;
 
     public static ProblemDto from(Problem problem) {
         return ProblemDto.builder()
@@ -18,6 +19,7 @@ public class ProblemDto {
             .problemId(problem.getId())
             .title(problem.getTitle())
             .tier(problem.getTier())
+            .bojUrl(problem.getBojUrl())
             .build();
     }
 }

--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSolutionResponseDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSolutionResponseDto.java
@@ -7,6 +7,7 @@ import java.util.Map;
 @Getter
 @Builder
 public class ProblemSolutionResponseDto {
+    private String bojUrl;
     private Long problemNumber;
     private String tier;
     private String title;

--- a/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/ProblemSetService.java
@@ -79,6 +79,7 @@ public class ProblemSetService {
             .orElseThrow(() -> new ResourceNotFoundException("해당 문제에 대한 해설이 없습니다."));
 
         return ProblemSolutionResponseDto.builder()
+            .bojUrl(problem.getBojUrl())
             .problemNumber(problem.getNumber())
             .tier(problem.getTier())
             .title(problem.getTitle())

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -33,6 +33,7 @@ public class UserController {
     private final UserService userService;
     private final ImageUploader imageUploader;
 
+    // 유저 탈퇴하기
     @DeleteMapping("/me")
     public ResponseEntity<ApiResponse<?>> deleteUser(HttpServletResponse response) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -41,6 +42,7 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
+    // 유저 정보 수정
     @PostMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserResponse> updateUserInfo(
         @RequestPart(value = "nickname", required = false) String nickname,
@@ -55,6 +57,7 @@ public class UserController {
         return ResponseEntity.ok(UserResponse.ofSuccess());
     }
 
+    // 유저 정보 조회
     @GetMapping(value = "/me")
     public ResponseEntity<?> getUserInfo() {
         try {

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -1,16 +1,14 @@
 package icet.koco.user.controller;
 
 import icet.koco.global.dto.ApiResponse;
-import icet.koco.user.dto.DashboardResponseDto;
+import icet.koco.user.dto.UserAlgorithmStatsResponseDto;
 import icet.koco.user.dto.UserInfoResponseDto;
 import icet.koco.user.dto.UserResponse;
 import icet.koco.user.service.UserService;
 import icet.koco.user.service.uploader.ImageUploader;
 import jakarta.servlet.http.HttpServletResponse;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,7 +16,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -71,14 +68,14 @@ public class UserController {
     }
 
 
-    @GetMapping("/dashboard")
-    public ResponseEntity<?> getDashboard(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    @GetMapping("/algorithm-stats")
+    public ResponseEntity<?> getAlgorithmStats () {
         try {
             Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-            DashboardResponseDto response = userService.getUserDashboard(userId, date);
-            return ResponseEntity.ok(ApiResponse.success("USER_DASHBOARD_GET_SUCCESS", "유저 프로필 정보 조회 성공", response));
+            UserAlgorithmStatsResponseDto response = userService.getAlgorithmStats(userId);
+            return ResponseEntity.ok(ApiResponse.success("USER_ALGORITHM_STATS_GET_SUCCESS", "유저 알고리즘 스탯 정보 조회 성공", response));
         } catch (Exception e) {
-            log.error("대시보드 API 에러 발생", e);
+            log.error("사용자 알고리즘 스탯 조회 API 에러 발생", e);
             e.printStackTrace(); // 콘솔에 전체 에러 출력
             return ResponseEntity.internalServerError().body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "서버 내부 에러"));
         }

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -2,6 +2,7 @@ package icet.koco.user.controller;
 
 import icet.koco.global.dto.ApiResponse;
 import icet.koco.user.dto.DashboardResponseDto;
+import icet.koco.user.dto.UserInfoResponseDto;
 import icet.koco.user.dto.UserResponse;
 import icet.koco.user.service.UserService;
 import icet.koco.user.service.uploader.ImageUploader;
@@ -54,18 +55,29 @@ public class UserController {
         return ResponseEntity.ok(UserResponse.ofSuccess());
     }
 
+    @GetMapping(value = "/me")
+    public ResponseEntity<?> getUserInfo() {
+        try {
+            Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+            UserInfoResponseDto userInfoResponseDto = userService.getUserInfo(userId);
+            return ResponseEntity.ok(ApiResponse.success("USER_INFO_GET_SUCCESS", "유저 프로필 정보 조회 성공", userInfoResponseDto));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).body(ApiResponse.fail("SERVER_ERROR", "서버 에러"));
+        }
+    }
+
+
     @GetMapping("/dashboard")
     public ResponseEntity<?> getDashboard(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         try {
-            Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-            Long userId = Long.valueOf(principal.toString());
+            Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
             DashboardResponseDto response = userService.getUserDashboard(userId, date);
             return ResponseEntity.ok(ApiResponse.success("USER_DASHBOARD_GET_SUCCESS", "유저 프로필 정보 조회 성공", response));
         } catch (Exception e) {
             log.error("대시보드 API 에러 발생", e);
             e.printStackTrace(); // 콘솔에 전체 에러 출력
-            return ResponseEntity.internalServerError().body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "셔벼 내부 에러"));
+            return ResponseEntity.internalServerError().body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "서버 내부 에러"));
         }
     }
 

--- a/Koco/src/main/java/icet/koco/user/dto/UserAlgorithmStatsResponseDto.java
+++ b/Koco/src/main/java/icet/koco/user/dto/UserAlgorithmStatsResponseDto.java
@@ -6,12 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class DashboardResponseDto {
-    private Long userId;
-    private String nickname;
-    private String statusMessage;
-    private String profileImgUrl;
-    private Long todayProblemSetId;
+public class UserAlgorithmStatsResponseDto {
     private List<CategoryStat> studyStats;
 
     @Getter

--- a/Koco/src/main/java/icet/koco/user/dto/UserInfoResponseDto.java
+++ b/Koco/src/main/java/icet/koco/user/dto/UserInfoResponseDto.java
@@ -1,0 +1,13 @@
+package icet.koco.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponseDto {
+    private Long userId;
+    private String nickname;
+    private String statusMessage;
+    private String profileImageUrl;
+}

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -1,5 +1,6 @@
 package icet.koco.user.service;
 
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import icet.koco.auth.entity.OAuth;
 import icet.koco.auth.repository.OAuthRepository;
 import icet.koco.auth.service.KakaoOAuthClient;
@@ -12,6 +13,7 @@ import icet.koco.problemSet.repository.SolutionRepository;
 import icet.koco.problemSet.repository.SurveyRepository;
 import icet.koco.user.dto.DashboardResponseDto;
 import icet.koco.user.dto.UserCategoryStatProjection;
+import icet.koco.user.dto.UserInfoResponseDto;
 import icet.koco.user.entity.User;
 import icet.koco.user.entity.UserAlgorithmStats;
 import icet.koco.user.repository.UserAlgorithmStatsRepository;
@@ -79,6 +81,20 @@ public class UserService {
         if (nickname != null) user.setNickname(nickname);
         if (profileImgUrl != null) user.setProfileImgUrl(profileImgUrl);
         if (statusMsg != null) user.setStatusMsg(statusMsg);
+    }
+
+    // 사용자 정보 반환 (userId, nickname, statusMsg, profileImgUrl)
+    @Transactional(readOnly = true)
+    public UserInfoResponseDto getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        return UserInfoResponseDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .statusMessage(user.getStatusMsg())
+                .profileImageUrl(user.getProfileImgUrl())
+                .build();
     }
 
     @Transactional

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -1,21 +1,17 @@
 package icet.koco.user.service;
 
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import icet.koco.auth.entity.OAuth;
 import icet.koco.auth.repository.OAuthRepository;
 import icet.koco.auth.service.KakaoOAuthClient;
 import icet.koco.global.exception.ResourceNotFoundException;
 import icet.koco.global.exception.UnauthorizedException;
-import icet.koco.problemSet.entity.Category;
 import icet.koco.problemSet.entity.ProblemSet;
 import icet.koco.problemSet.repository.ProblemSetRepository;
-import icet.koco.problemSet.repository.SolutionRepository;
 import icet.koco.problemSet.repository.SurveyRepository;
 import icet.koco.user.dto.DashboardResponseDto;
 import icet.koco.user.dto.UserCategoryStatProjection;
 import icet.koco.user.dto.UserInfoResponseDto;
 import icet.koco.user.entity.User;
-import icet.koco.user.entity.UserAlgorithmStats;
 import icet.koco.user.repository.UserAlgorithmStatsRepository;
 import icet.koco.user.repository.UserRepository;
 import icet.koco.util.CookieUtil;
@@ -44,6 +40,11 @@ public class UserService {
     private final UserAlgorithmStatsService userAlgorithmStatsService;
 
 
+    /**
+     * 유저 탈퇴
+     * @param userId
+     * @param response
+     */
     @Transactional
     public void deleteUser(Long userId, HttpServletResponse response) {
         // 1. 유저 조회
@@ -73,6 +74,13 @@ public class UserService {
         cookieUtil.invalidateCookie(response, "refresh_token");
     }
 
+    /**
+     * 유저 정보 수정(업데이트)
+     * @param userId
+     * @param nickname
+     * @param profileImgUrl
+     * @param statusMsg
+     */
     @Transactional
     public void updateUserInfo(Long userId, String nickname, String profileImgUrl, String statusMsg) {
         User user = userRepository.findById(userId)
@@ -83,7 +91,11 @@ public class UserService {
         if (statusMsg != null) user.setStatusMsg(statusMsg);
     }
 
-    // 사용자 정보 반환 (userId, nickname, statusMsg, profileImgUrl)
+    /**
+     * 유저 정보 조회
+     * @param userId
+     * @return
+     */
     @Transactional(readOnly = true)
     public UserInfoResponseDto getUserInfo(Long userId) {
         User user = userRepository.findById(userId)
@@ -97,6 +109,7 @@ public class UserService {
                 .build();
     }
 
+    // userAlgorithmStats 조회 API
     @Transactional
     public DashboardResponseDto getUserDashboard(Long userId, LocalDate date) {
         User user = userRepository.findById(userId).orElseThrow();


### PR DESCRIPTION
## 📝 개요
- 대시보드 조회 API 분리

## 🔗 연관된 이슈
- #30 

## 📋 작업할 내용
- [x] 유저 정보 조회 API
- [x] 특정 날짜에 출제된 출제문제집 조회 (기존 API에서 응답에 백준 url / bojUrl 추가) API
- [x] 유저 알고리즘 스탯 조회 API
- [x] 알고리즘 문제에 대한 해설 조회 API에 백준 url 추가

## 🔖 기타사항
- [ ] 알고리즘 스탯 조회 로직 변경 필요