### PR TITLE
[Fix] 토큰 만료 시 401 에러 반환 (#35)

### DIFF
--- a/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
+++ b/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
@@ -8,11 +8,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -41,20 +43,44 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         }
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            String isBlacklisted = redisTemplate.opsForValue().get("BL:" + token);
-            if (isBlacklisted != null) {
-                System.out.println(">>>>> 블랙리스트 토큰: 필터 차단");
+        if (token != null) {
+            System.out.println(">>>>> access_token 추출됨: " + token);
+
+            // 토큰 유효성 검사 실패
+            if (!jwtTokenProvider.validateToken(token)) {
+                System.out.println(">>>>> 토큰 유효성 검사 실패");
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                filterChain.doFilter(request, response);
+                response.setContentType("application/json");
+                response.getWriter().write("{\"error\": \"expired token\"}");
+                response.getWriter().flush();
                 return;
             }
 
+            // 블랙리스트 검사
+            String isBlacklisted = redisTemplate.opsForValue().get("BL:" + token);
+            if (isBlacklisted != null) {
+                System.out.println(">>>>> 블랙리스트 토큰");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.getWriter().write("{\"error\": \"BL checked. expired token\"}");
+                response.getWriter().flush();
+                return;
+            }
+
+            // 정상 토큰 → userId 추출 및 인증 객체 생성
             Long userId = jwtTokenProvider.getUserIdFromToken(token);
-            Authentication authentication = new UsernamePasswordAuthenticationToken(userId, null, List.of());
+            System.out.println(">>>>> userId 추출됨: " + userId);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    userId,
+                    null,
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+            );
             SecurityContextHolder.getContext().setAuthentication(authentication);
+            System.out.println(">>>>> SecurityContext에 인증 정보 저장 완료");
         }
 
+        // 다음 필터로 진행
         filterChain.doFilter(request, response);
     }
 }

--- a/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
+++ b/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
@@ -20,8 +20,10 @@ public class JwtTokenProvider {
 
     private SecretKey key;
     private final long accessTokenValidity = 1000 * 60 * 30; // 30분
-    private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 14; // 14일
+//    private final long accessTokenValidity = 5 * 1000L; // 30분
 
+    private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 14; // 14일
+//    private final long refreshTokenValidity = 5 * 1000L;
     @PostConstruct
     public void init() {
         this.key = Keys.hmacShaKeyFor(secret.getBytes());


### PR DESCRIPTION
## 📝 개요
- JWT를 통한 사용자 인증 처리 필터 구현

## 🔗 연관된 이슈
- #35 

## 🔄 변경사항 및 이유
- JwtAuthenticationFilter 클래스 구현
- 유효하지 않거나 만료된 토큰에 대해 401 응답 반환
- Redis를 통해 토큰 블랙리스트("BL:" + token) 검사
- 토큰 유효성 검사 실패 또는 블랙리스트된 토큰에 대해서는 JSON 에러 메시지와 함께 요청 중단

## 📋 작업한 내용
- [x] JWT 필터 생성 및 등록
- [x] 토큰 유효성 검사 추가
- [x] redis 블랙리스트 검사 로직 구현
- [x] 인증 성공 시 SecurityContextHolder 설정
