### PR TITLE
[Chore] 로컬에서 작업 시 디스코드 알람 가지 않는 기능 수정 (#44)

### DIFF
--- a/Koco/build.gradle
+++ b/Koco/build.gradle
@@ -21,7 +21,7 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://jitpack.io' } // 디스코드 알림
+	maven { url = uri("https://jitpack.io") } // 디스코드 알림
 }
 
 dependencies {
@@ -35,6 +35,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/Koco/src/main/resources/apllication-prod.yml
+++ b/Koco/src/main/resources/apllication-prod.yml
@@ -1,0 +1,5 @@
+logging:
+  discord:
+    enabled: true
+    webhook-url: https://discord.com/api/webhooks/1372464453630558221/d7FNPuVXrdne7MzIB0ZrfunlcgaldOb9KxmWAjrxrsub7PsAuXHqOHhwMyTPUpTubIf-
+    config: classpath:logback-spring.xml

--- a/Koco/src/main/resources/application-local.yml
+++ b/Koco/src/main/resources/application-local.yml
@@ -1,0 +1,5 @@
+# 로컬 전용 설정 (application-local.yml)
+
+logging:
+  discord:
+    enabled: false  # 알림 비활성화

--- a/Koco/src/main/resources/application.yml
+++ b/Koco/src/main/resources/application.yml
@@ -1,4 +1,12 @@
+spring:
+  profiles:
+    active: local  # or prod (배포 시)
+
+# 공통 설정 (application.yml)
+
 logging:
-  discord:
-    webhook-url: https://discord.com/api/webhooks/1372464453630558221/d7FNPuVXrdne7MzIB0ZrfunlcgaldOb9KxmWAjrxrsub7PsAuXHqOHhwMyTPUpTubIf-
-    config: classpath:logback-spring.xml
+  level:
+    root: INFO
+
+
+

--- a/Koco/src/main/resources/logback-spring.xml
+++ b/Koco/src/main/resources/logback-spring.xml
@@ -1,18 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="console-appender.xml"/>
-    <include resource="discord-error-appender.xml"/>
-    <appender-ref ref="ASYNC_DISCORD" />
-
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+
     <!-- 로깅 테마 -->
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
 
-    <springProperty name="DISCORD_ERROR_WEBHOOK_URL" source="logging.discord.webhook-url"/>
+    <!-- Spring 환경 변수 -->
+    <springProperty name="DISCORD_ENABLED" source="logging.discord.enabled" defaultValue="false"/>
+    <springProperty name="DISCORD_ERROR_WEBHOOK_URL" source="logging.discord.webhook-url" defaultValue=""/>
 
+    <!-- 콘솔 로그 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 루트 로거 설정 -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="ASYNC_DISCORD" />
     </root>
-
 </configuration>


### PR DESCRIPTION
## 📝 개요
- 로컬 작업 시 디스코드 오류 전송 X

## 🔗 연관된 이슈
- #44 

## 🔄 변경사항 및 이유
- 로컬에서 SpringBoot 애플리케이션 실행 시 Error봇 작동 X

## 📋 작업할 내용
- [ ] 의존성 추가
