### PR TITLE
[Chore] Health Check API (#51)

### DIFF
--- a/Koco/build.gradle
+++ b/Koco/build.gradle
@@ -44,7 +44,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'				// swagger 사용 의존성
-	implementation 'com.github.napstr:logback-discord-appender:1.0.0' // 디스코드 알림
+	implementation 'com.github.napstr:logback-discord-appender:1.0.0' 						// 디스코드 알림
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'					// health check API
 }
 
 tasks.named('test') {

--- a/Koco/src/main/java/icet/koco/config/SecurityConfig.java
+++ b/Koco/src/main/java/icet/koco/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/backend/v1/auth/**","/api/backend/v1/solution", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**")
+                .requestMatchers("/api/backend/v1/auth/**","/api/backend/v1/solution", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/actuator/**")
                 .permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
## 📝 개요
- Health Check API

## 🔗 연관된 이슈
- close #51 

## 📋 작업한 내용
- [x] `org.springframework.boot:spring-boot-starter-actuator` 의존성 추가
- [x]  `/actuator/health` 경로 필터 예외 처리
- [x] Spring Security에서 해당 경로 별도의 인증없이도 접근 가능

## 🔗 참고 자료 (선택)
- [Spring Boot Actuator의 헬스체크 살펴보기](https://toss.tech/article/how-to-work-health-check-in-spring-boot-actuator)
- [Spring Docs](https://docs.spring.io/spring-boot/docs/3.0.5/reference/html/actuator.html#actuator.endpoints.health)
