### PR TITLE
[Chore] 회원 정보 등록 RequestParam에서 RequestBody로 변경 (#55)

### DIFF
--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -2,8 +2,8 @@ package icet.koco.user.controller;
 
 import icet.koco.global.dto.ApiResponse;
 import icet.koco.user.dto.UserAlgorithmStatsResponseDto;
+import icet.koco.user.dto.UserInfoRequestDto;
 import icet.koco.user.dto.UserInfoResponseDto;
-import icet.koco.user.dto.UserResponse;
 import icet.koco.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,19 +37,23 @@ public class UserController {
 
     @Operation(summary = "유저 정보 등록")
     @PostMapping(value = "/me")
-    public ResponseEntity<?> postUserInfo(
-            @RequestParam(value = "nickname", required = false) String nickname,
-            @RequestParam(value = "statusMsg", required = false) String statusMsg,
-            @RequestParam(value = "profileImgUrl", required = false) String profileImgUrl) {
-        System.out.println("nickname: " + nickname);
-        System.out.println("statusMsg: " + statusMsg);
-        System.out.println("profileImgUrl: " + profileImgUrl);
-
+    public ResponseEntity<?> postUserInfo(@RequestBody UserInfoRequestDto userInfoRequestDto) {
         Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-        userService.postUserInfo(userId, nickname, profileImgUrl, statusMsg);
+        // DTO 통해서 유저 정보 받아오기
+        String nickname = userInfoRequestDto.getNickname();
+        String statusMsg = userInfoRequestDto.getStatusMsg();
+        String profileImgUrl = userInfoRequestDto.getProfileImgUrl();
 
-        return ResponseEntity.ok(UserResponse.ofSuccess());
+        // 유저 정보 설정
+        userService.postUserInfo(userId, nickname, statusMsg, profileImgUrl);
+
+        // 성공 응답 반환
+        return ResponseEntity.ok(ApiResponse.success(
+                "USER_INFO_POST_SUCCESS",
+                "유저 정보를 등록하는데 성공했습니다",
+                null
+        ));
     }
 
 

--- a/Koco/src/main/java/icet/koco/user/controller/UserController.java
+++ b/Koco/src/main/java/icet/koco/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package icet.koco.user.controller;
 
 import icet.koco.global.dto.ApiResponse;
+import icet.koco.global.exception.UnauthorizedException;
 import icet.koco.user.dto.UserAlgorithmStatsResponseDto;
 import icet.koco.user.dto.UserInfoRequestDto;
 import icet.koco.user.dto.UserInfoResponseDto;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -35,25 +37,64 @@ public class UserController {
     }
 
 
+    /**
+     * 유저 정보 등록 API (초기 등록)
+     * @param userInfoRequestDto
+     * @return
+     */
     @Operation(summary = "유저 정보 등록")
     @PostMapping(value = "/me")
     public ResponseEntity<?> postUserInfo(@RequestBody UserInfoRequestDto userInfoRequestDto) {
-        Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        try {
+            Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-        // DTO 통해서 유저 정보 받아오기
-        String nickname = userInfoRequestDto.getNickname();
-        String statusMsg = userInfoRequestDto.getStatusMsg();
-        String profileImgUrl = userInfoRequestDto.getProfileImgUrl();
+            // DTO 통해서 유저 정보 받아오기
+            String nickname = userInfoRequestDto.getNickname();
+            String statusMsg = userInfoRequestDto.getStatusMsg();
+            String profileImgUrl = userInfoRequestDto.getProfileImgUrl();
 
-        // 유저 정보 설정
-        userService.postUserInfo(userId, nickname, statusMsg, profileImgUrl);
+            // 유저 정보 설정
+            userService.postUserInfo(userId, nickname, statusMsg, profileImgUrl);
 
-        // 성공 응답 반환
-        return ResponseEntity.ok(ApiResponse.success(
-                "USER_INFO_POST_SUCCESS",
-                "유저 정보를 등록하는데 성공했습니다",
-                null
-        ));
+            // 204 No content 응답
+            return ResponseEntity.noContent().build();
+
+        } catch (UnauthorizedException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail("UNAUTHORIZED", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "알 수 없는 서버 에러"));
+        }
+    }
+
+    /**
+     * 유저 정보 수정 API
+     * @param userInfoRequestDto
+     * @return
+     */
+    @PatchMapping("/me")
+    public ResponseEntity<?> updateUserInfo(@RequestBody UserInfoRequestDto userInfoRequestDto) {
+        try {
+            Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+            String nickname = userInfoRequestDto.getNickname();
+            String statusMsg = userInfoRequestDto.getStatusMsg();
+            String profileImgUrl = userInfoRequestDto.getProfileImgUrl();
+
+            // 유저 정보 설정
+            userService.updateUserInfo(userId, nickname, statusMsg, profileImgUrl);
+
+            // 204 No content 응답
+            return ResponseEntity.noContent().build();
+
+        } catch (UnauthorizedException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail("UNAUTHORIZED", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.fail("INTERNAL_SERVER_ERROR", "알 수 없는 서버 에러"));
+        }
     }
 
 

--- a/Koco/src/main/java/icet/koco/user/dto/UserInfoRequestDto.java
+++ b/Koco/src/main/java/icet/koco/user/dto/UserInfoRequestDto.java
@@ -1,0 +1,12 @@
+package icet.koco.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoRequestDto {
+    private String nickname;
+    private String statusMsg;
+    private String profileImgUrl;
+}

--- a/Koco/src/main/java/icet/koco/user/dto/UserInfoResponseDto.java
+++ b/Koco/src/main/java/icet/koco/user/dto/UserInfoResponseDto.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public class UserInfoResponseDto {
     private Long userId;
     private String nickname;
-    private String statusMessage;
-    private String profileImageUrl;
+    private String statusMsg;
+    private String profileImgUrl;
 }

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -35,11 +35,7 @@ public class UserService {
     private final RedisTemplate<String, String> redisTemplate;
     private final OAuthRepository oAuthRepository;
     private final CookieUtil cookieUtil;
-    private final ProblemSetRepository problemSetRepository;
-    private final SurveyRepository surveyRepository;
     private final UserAlgorithmStatsRepository userAlgorithmStatsRepository;
-    private final UserAlgorithmStatsService userAlgorithmStatsService;
-
 
     /**
      * 유저 탈퇴
@@ -83,21 +79,35 @@ public class UserService {
      * @param statusMsg
      */
     @Transactional
-    public void updateUserInfo(Long userId, String nickname, String profileImgUrl, String statusMsg) {
+    public void updateUserInfo(Long userId, String nickname, String statusMsg, String profileImgUrl) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다"));
 
-        String userName = user.getName();
+        if (nickname != null) {
+            user.setNickname(nickname);
+        }
 
-        user.setNickname(nickname!=null?nickname:userName);
-        user.setProfileImgUrl(profileImgUrl);
-        user.setStatusMsg(statusMsg);
+        if (profileImgUrl != null) {
+            user.setProfileImgUrl(profileImgUrl);
+        }
+
+        if (statusMsg != null) {
+            user.setStatusMsg(statusMsg);
+        }
 
         userRepository.save(user);
     }
 
+
+    /**
+     * 유저 정보 등록
+     * @param userId
+     * @param nickname
+     * @param statusMsg
+     * @param profileImgUrl
+     */
     @Transactional
-    public void postUserInfo(Long userId, String nickname, String profileImgUrl, String statusMsg) {
+    public void postUserInfo(Long userId, String nickname, String statusMsg, String profileImgUrl) {
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new RuntimeException("유저를 찾을 수 없습니다."));
 
@@ -123,8 +133,8 @@ public class UserService {
         return UserInfoResponseDto.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
-                .statusMessage(user.getStatusMsg())
-                .profileImageUrl(user.getProfileImgUrl())
+                .statusMsg(user.getStatusMsg())
+                .profileImgUrl(user.getProfileImgUrl())
                 .build();
     }
 


### PR DESCRIPTION
## 📝 개요
- 유저 정보 등록 및 수정 API의 요청 방식을 @RequestParam → @RequestBody로 변경
- PATCH 방식의 유저 정보 수정 API 구현

## 🔗 연관된 이슈
- #55 

## 🔄 변경사항 및 이유
- 변경사항
  - 기존 `@RequestParam` 방식으로 개별 필드를 받던 유저 등록 API를 `@RequestBody`로 통합
  - PATCH /users/me 요청 시 JSON에서 포함된 필드만 반영되도록 서비스 로직 수정

- 변경 이유
  - RESTful한 API 스타일을 따르기 위해 Body 기반 요청 방식으로 일원화
  - 선택적 필드 업데이트가 가능하도록 하여 유연한 사용자 정보 수정 기능 제공

## 📋 작업한 내용
- [x] 유저 정보 등록 API `@RequestBody` 기반으로 리팩토링
- [x] 유저 정보 수정 API에서 null 필드 무시 로직 적용 (if (x != null))
- [x] 불필요한 `@RequestParam` 제거 및 컨트롤러 메서드 정리
- [x] Postman 테스트 완료