### PR TITLE
[Fix] accessToken 만료 시 refreshToken 재발급 요청 실패 수정 (#35)

### DIFF
--- a/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
+++ b/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
@@ -28,6 +28,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getRequestURI().equals("/api/backend/v1/auth/refresh");
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request,
         HttpServletResponse response,
         FilterChain filterChain)

--- a/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
+++ b/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
@@ -16,8 +16,8 @@ public class JwtTokenProvider {
     private String secret;
 
     private SecretKey key;
-//    private final long accessTokenValidity = 1000 * 60 * 30; // 30분
-    private final long accessTokenValidity = 5 * 1000L; // 5초
+    private final long accessTokenValidity = 1000 * 60 * 30; // 30분
+//    private final long accessTokenValidity = 5 * 1000L; // 5초
 
     private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 14; // 14일
 //    private final long refreshTokenValidity = 5 * 1000L;

--- a/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
+++ b/Koco/src/main/java/icet/koco/util/JwtTokenProvider.java
@@ -1,10 +1,7 @@
 package icet.koco.util;
 
 import icet.koco.user.entity.User;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import java.util.Date;
@@ -19,8 +16,8 @@ public class JwtTokenProvider {
     private String secret;
 
     private SecretKey key;
-    private final long accessTokenValidity = 1000 * 60 * 30; // 30분
-//    private final long accessTokenValidity = 5 * 1000L; // 30분
+//    private final long accessTokenValidity = 1000 * 60 * 30; // 30분
+    private final long accessTokenValidity = 5 * 1000L; // 5초
 
     private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 14; // 14일
 //    private final long refreshTokenValidity = 5 * 1000L;
@@ -53,9 +50,16 @@ public class JwtTokenProvider {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
+        } catch (ExpiredJwtException e) {
+            System.out.println("❌ 만료된 토큰입니다.");
+        } catch (SignatureException e) {
+            System.out.println("❌ 서명 오류 (key가 맞지 않음).");
+        } catch (MalformedJwtException e) {
+            System.out.println("❌ 잘못된 형식의 토큰.");
+        } catch (Exception e) {
+            System.out.println("❌ 기타 오류: " + e.getMessage());
         }
+        return false;
     }
 
     public Long getUserIdFromToken(String token) {


### PR DESCRIPTION
# TITLE
[Feat] 회원가입 기능 구현 (#이슈번호)

## 📝 개요
- accessToken이 만료된 경우에도 refreshToken을 사용한 재발급 요청(/api/backend/v1/auth/refresh)이 정상 처리되도록 필터 예외 처리를 추가


## 🔗 연관된 이슈
- #이슈번호
- 여러 개 연관 시 모두 명시

## 🔄 변경사항 및 이유
- JwtAuthenticationFilter 클래스에 shouldNotFilter() 메서드를 오버라이드하여 /api/backend/v1/auth/refresh 요청에 대해서는 accessToken 검증 로직을 건너뛰도록 처리
- 기존에는 accessToken이 만료되면 무조건 401 응답이 발생해 refreshToken 기반 재발급 요청도 실패함 → 토큰 갱신 로직 동작 불가

## 📋 작업할 내용
- [ ]  shouldNotFilter() 메서드 오버라이드 추가
- [ ] /api/backend/v1/auth/refresh URI에 대해서는 필터 건너뛰도록 예외 처리
- [ ] accessToken 만료 상태에서도 refreshToken만으로 새로운 accessToken을 정상 발급 가능하게 수정

## 🔖 기타사항
- [x] dev에 merge 하는가 확인
- [x] 기존 기능 돌아가는지 확인
- [x] 새로 추가한 기능 돌아가는지 확인


## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성
- ex) "메서드 네이밍을 더 직관적으로 만들고 싶은데 조언 부탁드립니다."

## 🔗 참고 자료 (선택)
- [Spring Security - OncePerRequestFilter 공식 문서](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/OncePerRequestFilter.html)
