### PR TITLE
[Chore]JWT 필터 개선 및 부하테스트용 Access/Refresh Token 발급 (#71)

### DIFF
--- a/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
+++ b/Koco/src/main/java/icet/koco/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package icet.koco.auth.controller;
 
 import icet.koco.auth.dto.*;
 import icet.koco.auth.service.AuthService;
+import icet.koco.global.dto.ApiResponse;
 import icet.koco.global.exception.UnauthorizedException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -54,14 +55,15 @@ public class AuthController {
      */
     @Operation(summary = "리프레쉬 토큰 기반 재발급")
     @PostMapping("/refresh")
-    public ResponseEntity<RefreshResponse> refreshToken(
+    public ResponseEntity<?> refreshToken(
             @CookieValue(value = "refresh_token") String refreshToken,
             HttpServletResponse response) {
         try {
             RefreshResponse refreshResponse = authService.refreshAccessToken(refreshToken, response);
-            return ResponseEntity.ok(refreshResponse);
+            return ResponseEntity.ok(ApiResponse.success("TOKEN_REFRESH_SUCCESS", "토큰 재발급에 성공하였습니다.", refreshResponse));
         } catch (UnauthorizedException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail("UNAUTHORIZED_ERROR", "리프레시 토큰이 유효하지 않습니다."));
         }
     }
 }

--- a/Koco/src/main/java/icet/koco/auth/service/AuthService.java
+++ b/Koco/src/main/java/icet/koco/auth/service/AuthService.java
@@ -58,6 +58,7 @@ public class AuthService {
 
             // RefreshToken Redis에 저장
             String refreshToken = jwtTokenProvider.createRefreshToken(user);
+            System.out.println("refreshToken: " + refreshToken);
             try {
                 redisTemplate.opsForValue().set(user.getId().toString(), refreshToken);
             } catch (Exception e) {
@@ -77,6 +78,7 @@ public class AuthService {
 
             // accessToken 발급
             String accessToken = jwtTokenProvider.createAccessToken(user);
+            System.out.println("accessToken: " + accessToken);
 
             // accessToken 쿠키로 전달
             Cookie accessTokenCookie = new Cookie("access_token", accessToken);

--- a/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
+++ b/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
@@ -39,7 +39,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throws ServletException, IOException {
 
         String token = null;
-        if (request.getCookies() != null) {
+//        // 1️⃣ Authorization 헤더 우선
+//        String bearer = request.getHeader("Authorization");
+//        if (bearer != null && bearer.startsWith("Bearer ")) {
+//            token = bearer.substring(7);
+//        }
+//
+//        // 2️⃣ Authorization 헤더 없으면 쿠키에서 찾기
+        if (token == null && request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
                 if ("access_token".equals(cookie.getName())) {
                     token = cookie.getValue();

--- a/Koco/src/main/java/icet/koco/util/test/TestJwtGenerator.java
+++ b/Koco/src/main/java/icet/koco/util/test/TestJwtGenerator.java
@@ -1,0 +1,69 @@
+package icet.koco.util.test;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Component
+@Profile({"dev", "test"})
+public class TestJwtGenerator implements CommandLineRunner {
+    private final String secret = "asgfdvhbjghbnmdfbgvehajkldkjnbvsabnmmnbas";
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    long accessTokenValidity = 1000 * 60 * 30;            // 30분
+    long refreshTokenValidity = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    @Override
+    public void run(String... args) {
+        generateTokenCsv();
+    }
+
+    public Map<String, String> createTokenSet(Long userId) {
+        Date now = new Date();
+
+        String accessToken = Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenValidity))
+                .signWith(key)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenValidity))
+                .signWith(key)
+                .compact();
+
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("accessToken", accessToken);
+        tokens.put("refreshToken", refreshToken);
+        return tokens;
+    }
+
+    public void generateTokenCsv() {
+        System.out.println("userId,accessToken,refreshToken");
+
+        for (long userId = 200; userId <= 300; userId++) {
+            Map<String, String> tokenSet = createTokenSet(userId);
+            System.out.println(userId + "," + tokenSet.get("accessToken") + "," + tokenSet.get("refreshToken"));
+        }
+    }
+}

--- a/Koco/src/main/java/icet/koco/util/test/TestJwtGenerator.java
+++ b/Koco/src/main/java/icet/koco/util/test/TestJwtGenerator.java
@@ -1,69 +1,79 @@
-package icet.koco.util.test;
-
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-
-@Component
-@Profile({"dev", "test"})
-public class TestJwtGenerator implements CommandLineRunner {
-    private final String secret = "asgfdvhbjghbnmdfbgvehajkldkjnbvsabnmmnbas";
-
-    private SecretKey key;
-
-    @PostConstruct
-    public void init() {
-        this.key = Keys.hmacShaKeyFor(secret.getBytes());
-    }
-
-    long accessTokenValidity = 1000 * 60 * 30;            // 30분
-    long refreshTokenValidity = 1000 * 60 * 60 * 24 * 7;  // 7일
-
-    @Override
-    public void run(String... args) {
-        generateTokenCsv();
-    }
-
-    public Map<String, String> createTokenSet(Long userId) {
-        Date now = new Date();
-
-        String accessToken = Jwts.builder()
-                .setSubject(String.valueOf(userId))
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + accessTokenValidity))
-                .signWith(key)
-                .compact();
-
-        String refreshToken = Jwts.builder()
-                .setSubject(String.valueOf(userId))
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + refreshTokenValidity))
-                .signWith(key)
-                .compact();
-
-        Map<String, String> tokens = new HashMap<>();
-        tokens.put("accessToken", accessToken);
-        tokens.put("refreshToken", refreshToken);
-        return tokens;
-    }
-
-    public void generateTokenCsv() {
-        System.out.println("userId,accessToken,refreshToken");
-
-        for (long userId = 200; userId <= 300; userId++) {
-            Map<String, String> tokenSet = createTokenSet(userId);
-            System.out.println(userId + "," + tokenSet.get("accessToken") + "," + tokenSet.get("refreshToken"));
-        }
-    }
-}
+//package icet.koco.util.test;
+//
+//import io.jsonwebtoken.Jwts;
+//import io.jsonwebtoken.security.Keys;
+//import jakarta.annotation.PostConstruct;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.context.annotation.Profile;
+//import org.springframework.stereotype.Component;
+//
+//import javax.crypto.SecretKey;
+//import java.io.FileWriter;
+//import java.io.IOException;
+//import java.util.Date;
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//
+//@Component
+//@Profile({"dev", "test"})
+//public class TestJwtGenerator implements CommandLineRunner {
+//    String secret = "TzzH9y4xTeyKwO9FqWGevKmFkuYs8YXd2q2muydf2fM=";
+//
+//    private SecretKey key;
+//
+//    @PostConstruct
+//    public void init() {
+//        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+//    }
+//
+//    long accessTokenValidity = 1000L * 60 * 60 * 24;            // 1일
+//    long refreshTokenValidity = 1000L * 60 * 60 * 24 * 30;      // 30일
+//
+//    @Override
+//    public void run(String... args) {
+//        generateTokenCsv();
+//    }
+//
+//    public Map<String, String> createTokenSet(Long userId) {
+//        Date now = new Date();
+//
+//        String accessToken = Jwts.builder()
+//                .setSubject(String.valueOf(userId))
+//                .setIssuedAt(now)
+//                .setExpiration(new Date(now.getTime() + accessTokenValidity))
+//                .signWith(key)
+//                .compact();
+//
+//        String refreshToken = Jwts.builder()
+//                .setSubject(String.valueOf(userId))
+//                .setIssuedAt(now)
+//                .setExpiration(new Date(now.getTime() + refreshTokenValidity))
+//                .signWith(key)
+//                .compact();
+//
+//        Map<String, String> tokens = new HashMap<>();
+//        tokens.put("accessToken", accessToken);
+//        tokens.put("refreshToken", refreshToken);
+//        return tokens;
+//    }
+//
+//    public void generateTokenCsv() {
+//        String fileName = "tokens.csv";
+//
+//        try (FileWriter writer = new FileWriter(fileName)) {
+//            writer.write("user_id,access_token,refresh_token\n");
+//
+//            for (long userId = 273; userId <= 472; userId++) {
+//                Map<String, String> tokenSet = createTokenSet(userId);
+//                String line = userId + "," + tokenSet.get("accessToken") + "," + tokenSet.get("refreshToken") + "\n";
+//                writer.write(line);
+//            }
+//
+//            System.out.println("✅ CSV 파일이 성공적으로 저장되었습니다: " + fileName);
+//        } catch (IOException e) {
+//            System.err.println("❌ CSV 파일 저장 중 오류 발생: " + e.getMessage());
+//        }
+//    }
+//
+//}

--- a/Koco/src/main/resources/application.properties
+++ b/Koco/src/main/resources/application.properties
@@ -5,11 +5,10 @@ spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database=mysql
 spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.show-sql=true
 
 
 
-spring.profiles.active=prod
+spring.profiles.active=dev
 
 cloud.aws.credentials.access-key=${AWS_S3_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${AWS_S3_SECRET_KEY}


### PR DESCRIPTION
## 📝 개요
- JWT 기반 인증 필터(`JwtAuthenticationFilter`)를 개선하여 Authorization 헤더 방식 지원 추가
- JMeter 부하테스트용 더미 유저 AccessToken/RefreshToken 대량 발급(200명) CSV 생성 기능 추가
- 기존 쿠키 방식 외 Authorization 헤더 방식으로도 토큰 전송 가능하도록 로직 개선

## 🔗 연관된 이슈
- #71 

## 🔄 변경사항 및 이유
- `JwtAuthenticationFilter`: Authorization 헤더에서 Bearer 토큰 추출 처리 추가  
  → Postman, JMeter 등 헤더 기반 테스트 툴 사용 시 편의성 개선
- `JwtTokenProvider`: Access/RefreshToken 생성 로직 보강, secret 키 길이 점검
- `TestJwtGenerator`: 다수 유저의 Access/RefreshToken을 대량으로 발급하고 CSV로 저장하는 기능 구현  
  → 부하테스트용 JMeter 연동 데이터 파일 제공

## 📋 작업한 내용
- [x] JWT Authentication Filter 개선 (쿠키 + Authorization 헤더 지원)
- [x] Access/RefreshToken 생성용 유틸 클래스 보강
- [x] TestJwtGenerator로 CSV 파일 생성 기능 추가

## 🔖 기타사항
- [ ] JWT secret 키는 HS256 기준 최소 256bit 이상이어야 안전
- [ ] Postman, JMeter 테스트 시 CSV에서 각 쓰레드별 토큰이 올바르게 매핑되는지 Debug Sampler로 반드시 검증 필요
