### PR TITLE
[Fix] Description 자료형 변경 및 불일치 칼럼 수정 (#75)

### DIFF
--- a/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java
+++ b/Koco/src/main/java/icet/koco/auth/repository/OAuthRepository.java
@@ -18,7 +18,4 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
     @Modifying
     @Query("UPDATE OAuth o SET o.refreshToken = :refreshToken WHERE o.user.id = :userId")
     void updateRefreshToken(Long userId, String refreshToken);
-
-    Optional<OAuth> findByUserAndDeletedAtIsNull(Long userId);
-
 }

--- a/Koco/src/main/java/icet/koco/problemSet/entity/Problem.java
+++ b/Koco/src/main/java/icet/koco/problemSet/entity/Problem.java
@@ -33,7 +33,7 @@ public class Problem {
 
     // 문제 설명
     @Lob
-    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "description", nullable = false, columnDefinition = "LONGTEXT")
     private String description;
 
     // 입력 설명

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -50,7 +50,7 @@ public class UserService {
             .orElseThrow(() -> new ResourceNotFoundException("해당 유저 정보를 찾을 수 없습니다."));
 
         // 2. OAuth 정보 조회
-        OAuth oauth = oAuthRepository.findByUserAndDeletedAtIsNull(userId)
+        OAuth oauth = oAuthRepository.findByUserId(userId)
             .orElseThrow(() -> new UnauthorizedException("OAuth 정보가 존재하지 않습니다."));
 
         // 3. Kakao unlink 호출


### PR DESCRIPTION
## 📝 개요
- Description 자료형 변경 및 불일치 칼럼 수정 

## 🔗 연관된 이슈
- #75 

## 🔄 변경사항 및 이유
- findByUserIdAndNotNull 삭제
- description 자료형 LONGTEXT로 변경

## 📋 작업할 내용
- [ ] OAuth Repository에서 findByUserIdAndNotNull 삭제
- [ ] problem 테이블의 description 자료형 LONGTEXT로 변경
