### PR TITLE
[Fix] 게시글 검색 & 조회 기능 개선 (#109)

### DIFF
--- a/Koco/src/main/java/icet/koco/posts/dto/post/PostCreateEditRequestDto.java
+++ b/Koco/src/main/java/icet/koco/posts/dto/post/PostCreateEditRequestDto.java
@@ -1,11 +1,15 @@
 package icet.koco.posts.dto.post;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostCreateEditRequestDto {
     private Long problemNumber;
     private String title;

--- a/Koco/src/main/java/icet/koco/posts/entity/Post.java
+++ b/Koco/src/main/java/icet/koco/posts/entity/Post.java
@@ -33,7 +33,7 @@ public class Post {
     private String title;
 
     @Lob
-    @Column(name = "content")
+    @Column(name = "content", columnDefinition = "LONGTEXT")
     private String content;
 
     @Column(name = "comment_count")

--- a/Koco/src/main/java/icet/koco/posts/repository/PostRepository.java
+++ b/Koco/src/main/java/icet/koco/posts/repository/PostRepository.java
@@ -2,6 +2,7 @@ package icet.koco.posts.repository;
 
 import icet.koco.posts.entity.Post;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/Koco/src/main/java/icet/koco/posts/service/PostService.java
+++ b/Koco/src/main/java/icet/koco/posts/service/PostService.java
@@ -84,7 +84,6 @@ public class PostService {
                     .build();
             post.addPostCategory(postCategory);
             postCategoryRepository.save(postCategory);
-            System.out.println("Saving PostCategory with postId = " + post.getId() + ", categoryId = " + category.getId());
         }
 
         // DTO에 담아 반환

--- a/Koco/src/main/java/icet/koco/posts/service/PostService.java
+++ b/Koco/src/main/java/icet/koco/posts/service/PostService.java
@@ -52,10 +52,16 @@ public class PostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ForbiddenException("존재하지 않는 사용자입니다."));
 
+        List<Category> categories = categoryRepository.findByNameIn(requestDto.getCategory());
+
         // 해당 문제가 존재하는지 확인
         problemRepository.findByNumber(requestDto.getProblemNumber())
                 .orElseThrow(() -> new IllegalArgumentException(
-                        "해당 문제 번호를 가진 Problem이 없습니다."));
+                        "해당 문제 번호를 가진 백준 문제가 없습니다."));
+
+        if (categories.size() != requestDto.getCategory().size()) {
+            throw new IllegalArgumentException("존재하지 않는 카테고리가 포함되어 있습니다.");
+        }
 
         // Post Entity 생성
         Post post = Post.builder()
@@ -68,23 +74,18 @@ public class PostService {
                 .createdAt(now())
                 .build();
 
-        // 카테고리 이름으로 Category 조회
-        List<Category> categories = categoryRepository.findByNameIn(requestDto.getCategory());
-
-        if (categories.size() != requestDto.getCategory().size()) {
-            throw new IllegalArgumentException("존재하지 않는 카테고리가 포함되어 있습니다.");
-        }
+        postRepository.save(post);
 
         // 중간테이블에 카테고리 매핑
         for (Category category : categories) {
             PostCategory postCategory = PostCategory.builder()
+                    .post(post)
                     .category(category)
                     .build();
             post.addPostCategory(postCategory);
+            postCategoryRepository.save(postCategory);
+            System.out.println("Saving PostCategory with postId = " + post.getId() + ", categoryId = " + category.getId());
         }
-
-        // 저장
-        postRepository.save(post);
 
         // DTO에 담아 반환
         return PostCreateResponseDto.builder()
@@ -220,6 +221,7 @@ public class PostService {
 
         posts = postRepository.searchPosts(category, keyword, cursorId, size + 1);
 
+//        posts = postRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc();
         boolean hasNext = posts.size() > size;
 
         Long nextCursorId = null;

--- a/Koco/src/main/java/icet/koco/user/service/UserService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserService.java
@@ -132,9 +132,6 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("유저를 찾을 수 없습니다."));
 
-        System.out.println("로그인된 유저 Id: " + user.getId());
-        System.out.println("로그인된 유저 닉네임: " + user.getNickname());
-
         return UserInfoResponseDto.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())


### PR DESCRIPTION
## 📝 개요
- 게시글 검색 조건에 카테고리 필터 유무에 따라 전체 게시글을 조회하거나, 지정된 카테고리를 모두 포함하는 게시글만 필터링하도록 로직을 개선
- 게시글의 content 자료형 변경

## 🔗 연관된 이슈
- close #109 

## 🔄 변경사항 및 이유
- `searchPosts()` 메서드에 분기를 넣어 `categoryNames`가 비어 있을 경우 전체 게시글을 키워드만으로 검색할 수 있도록 수정
- 카테고리 조건이 존재할 경우, 게시글이 모든 카테고리를 포함한 경우에만 검색되도록 `having countDistinct()` 조건을 적용했습니다.
- 장문의 내용이 게시글 content에 삽입되지 않아, 해당 자료형 definition 을 LONGTEXT로 변경함

## 📋 작업한 내용
- [ ] 게시글 검색 조건 로직 분기 
- [ ] 자료형 변경
