### PR TITLE
[Fix] 회원 탈퇴 시 해당 사용자의 설문 응답 & 알고리즘 스탯 삭제 (#102)

### DIFF
--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
@@ -1,10 +1,14 @@
 package icet.koco.problemSet.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProblemSurveyRequestDto {
     private Long problemId;
     private boolean isSolved;

--- a/Koco/src/main/java/icet/koco/problemSet/repository/SurveyRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/SurveyRepository.java
@@ -3,6 +3,7 @@ package icet.koco.problemSet.repository;
 import icet.koco.problemSet.entity.Survey;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,4 +14,8 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
     List<Survey> findByUserId(Long userId);
 
+    // 사용자 Id로 작성된 설문 삭제
+    @Modifying
+    @Query("DELETE FROM Survey s WHERE s.user.id = :userId")
+    void deleteByUserId(@Param("userId")Long userId);
 }

--- a/Koco/src/main/java/icet/koco/user/repository/UserAlgorithmStatsRepository.java
+++ b/Koco/src/main/java/icet/koco/user/repository/UserAlgorithmStatsRepository.java
@@ -11,17 +11,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface UserAlgorithmStatsRepository extends JpaRepository<UserAlgorithmStats, Long> {
-
-    // 특정 사용자에 대한 전체 알고리즘 통계 조회
-    List<UserAlgorithmStats> findByUser(User user);
-
-    // 특정 사용자 + 카테고리 통계 조회
-    Optional<UserAlgorithmStats> findByUserIdAndCategoryId(Long userId, Long categoryId);
-
-    Optional<UserAlgorithmStats> findByUserAndCategory(User user, Category category);
-
     List<UserAlgorithmStats> findByUserId(Long userId);
 
+    // 사용자 Id로 작성된 알고리즘 스탯 삭제
     @Modifying
     @Query("DELETE FROM UserAlgorithmStats u WHERE u.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);


### PR DESCRIPTION
## 📝 개요
- 회원 탈퇴 시 해당 사용자의 설문 응답 & 알고리즘 스탯 삭제

## 🔗 연관된 이슈
- close #102 

## 🔄 변경사항 및 이유
- @Query, @Modifying을 이용하여 사용자의 알고리즘 통계 및 설문을 hard delete하는 쿼리 작성

## 📋 작업한 내용
- [x] SurveyRepository 수정
- [x] UserAlgorithmRepository 수정

