### PR TITLE
[Fix] 사용자 알고리즘 스탯 재갱신 안됨 (#113)

### DIFF
--- a/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/ProblemSurveyRequestDto.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ProblemSurveyRequestDto {
     private Long problemId;
-    private boolean isSolved;
+    private Boolean isSolved;
     private String difficultyLevel;
 }

--- a/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
@@ -61,7 +61,7 @@ public class SurveyService {
                 .user(user)
                 .problemSet(problemSet)
                 .problem(problem)
-                .isSolved(response.isSolved())
+                .isSolved(response.getIsSolved())
                 .difficultyLevel(DifficultyLevel.valueOf(response.getDifficultyLevel()))
                 .answeredAt(LocalDateTime.now())
                 .build();

--- a/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
+++ b/Koco/src/main/java/icet/koco/problemSet/service/SurveyService.java
@@ -79,8 +79,6 @@ public class SurveyService {
             .map(Survey::getId)
             .toList();
 
-        log.info(">>>>> 저장된 설문 ID 목록: {}", savedIds);
-
         return SurveyResponseDto.builder()
             .code("SURVEY_CREATED")
             .message("출제 문제집에 대한 설문응답이 성공적으로 생성되었습니다.")

--- a/Koco/src/main/java/icet/koco/user/service/UserAlgorithmStatsService.java
+++ b/Koco/src/main/java/icet/koco/user/service/UserAlgorithmStatsService.java
@@ -98,7 +98,6 @@ public class UserAlgorithmStatsService {
         }
 
         userAlgorithmStatsRepository.saveAll(statsToSave);
-        log.info(">>>>> 유저 {} 알고리즘 통계 {}건 저장 완료 (정규화 방식 적용)", userId, statsToSave.size());
     }
 
 }


### PR DESCRIPTION
## 📝 개요
-  사용자 알고리즘 스탯 재갱신 안됨 문제 해결

## 🔗 연관된 이슈
- #113 

## 🔄 변경사항 및 이유
- DTO의 `boolean` 타입을 `Boolean`으로 변경함
- 변경 이유
  - DTO 역직렬화 문제 (Jackson -> DTO) 
  - boolean(기본형)은 DTO에서 builder로 넘어갈 때 null이면 false로 처리됨
  - 그렇기에 builder를 통해서 생성된 데이터 값에 false가 들어가면서 사용자의 알고리즘 스탯이 갱신이 되지 않고 있었음

## 📋 작업한 내용
- [x] DTO의 `boolean`을 `Boolean`으로 변경
- [x] `@Getter`로 생성된 `getIsSolved()`로 호출함수 변경
