### PR TITLE
[Fix] 타임존 불일치 오류 해결 (#117)

### DIFF
--- a/Koco/src/main/java/icet/koco/config/SecurityConfig.java
+++ b/Koco/src/main/java/icet/koco/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/backend/v1/auth/**","/api/backend/v1/solution", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/actuator/**", "/api/backend/admin/today/problem-set")
+                .requestMatchers("/api/backend/v1/auth/**","/api/backend/v1/solution", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/actuator/**", "/api/backend/admin/today/problem-set", "/api/backend/test/timezone")
                 .permitAll()
                 .anyRequest().authenticated()
             )

--- a/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
+++ b/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
@@ -40,7 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.equals("/api/backend/v1/auth/refresh")
                 || path.equals("/api/backend/v1/auth/callback")
                 || path.equals("/oauth/kakao/callback")
-                || path.equals("/api/backend/admin/today/problem-set");
+                || path.equals("/api/backend/admin/today/problem-set")
+                || path.equals("/api/backend/test/token")
+                || path.equals("/api/backend/test/timezone");
+
     }
 
     @Override

--- a/Koco/src/main/java/icet/koco/util/test/TestAuthController.java
+++ b/Koco/src/main/java/icet/koco/util/test/TestAuthController.java
@@ -6,18 +6,22 @@ import icet.koco.user.repository.UserRepository;
 import icet.koco.util.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/test-auth")
-@Tag(name = "Test용")
+@RequestMapping("/api/backend/test")
+@Tag(name = "Test", description = "테스트용 API입니다.")
 public class TestAuthController {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -30,5 +34,18 @@ public class TestAuthController {
         String token = jwtTokenProvider.createAccessToken(user);
         System.out.println("testAuth token: " + token);
         return ResponseEntity.ok(Map.of("access_token", token));
+    }
+
+    @GetMapping("/timezone")
+    @Operation(summary = "타임존 확인용 API입니다.")
+    public ResponseEntity<Map<String, Object>> getCurrentServerTime() {
+        Map<String, Object> result = new HashMap<>();
+
+        result.put("localDateTime", LocalDateTime.now()); // 시간대 없음
+        result.put("zonedDateTime", ZonedDateTime.now()); // 시간대 포함
+        result.put("offsetDateTime", OffsetDateTime.now()); // 시간대 + 오프셋
+        result.put("jvmTimeZone", TimeZone.getDefault().getID()); // JVM 타임존
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/Koco/src/main/resources/application.properties
+++ b/Koco/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database=mysql
 spring.jpa.hibernate.ddl-auto=update
 
-
+spring.jackson.time-zone=Asia/Seoul
 
 spring.profiles.active=dev
 


### PR DESCRIPTION
## 📝 개요
- 개발 서버의 타임존 확인을 위해 타임존 확인 API 추가 구현

## 🔗 연관된 이슈
- #117 

## 🔄 변경사항 및 이유
- application.properties에 jackson.timezone 설정 추가
- 타임존 확인 API 구현

## 📋 작업할 내용
- [x] application.properties 수정
- [x] 타임존 확인 API 구현
