### PR TITLE
[Fix] ShouldNotFilter에 solution 경로 추가 (#121)

### DIFF
--- a/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
+++ b/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
@@ -37,12 +37,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/webjars/")
                 || path.startsWith("/actuator/")
+				|| path.startsWith("/api/backend/v1/solution")
                 || path.equals("/api/backend/v1/auth/refresh")
                 || path.equals("/api/backend/v1/auth/callback")
                 || path.equals("/oauth/kakao/callback")
                 || path.equals("/api/backend/admin/today/problem-set")
                 || path.equals("/api/backend/test/token")
                 || path.equals("/api/backend/test/timezone");
+
 
     }
 


### PR DESCRIPTION
## 📝 개요
- `JwtAuthenticationFilter`의 `shouldNotFilter` 로직에 `/api/backend/v1/solution` 경로를 토큰 검증 제외 대상에 추가

## 🔗 연관된 이슈
- CLOSE #121 

## 🔄 변경사항 및 이유
- AI 서버로부터 오는 해설 저장 API(/api/backend/v1/solution)는 별도의 인증 토큰 없이 호출되어야 하는데, 현재 필터가 이 경로에도 토큰 검증을 적용하여 500 에러가 발생하거나 요청이 차단됨
- 해당 경로를 예외 처리함으로써 AI → 백엔드 간 연동이 정상적으로 이루어지도록 수정함

## 📋 작업할 내용
- [x] shouldNotFilter에 `|| path.startsWith("/api/backend/v1/solution")` 추가