### PR TITLE
[HOTFIX] Dockerfile scouter.conf 생성 echo 명령 인용 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN mkdir -p /opt/scouter/agent.host/conf && \
 
 # Java Agent 설정
 RUN mkdir -p /opt/scouter/agent.java/conf && \
+    echo 'net_collector_ip=10.3.3.100\n\
     net_collector_udp_port=6100\n\
     net_collector_tcp_port=6100' > /opt/scouter/agent.java/conf/scouter.conf
 


### PR DESCRIPTION
hotfix(docker): echo로 scouter.conf 생성 방식 수정하여 문자열 인용 오류 해결

- Dockerfile: here-doc/printf 대신 echo + escape sequence 사용
- net_collector_* 설정이 올바르게 파일에 작성되도록 수정

---

# Java Agent 설정
RUN mkdir -p /opt/scouter/agent.java/conf && \
    echo 'net_collector_ip=10.1.3.100\n\
    net_collector_udp_port=6100\n\
    net_collector_tcp_port=6100' > /opt/scouter/agent.java/conf/scouter.conf

