### PR TITLE
[Feat] 해설 저장 시 문제집 매핑 기능 (#125)

### DIFF
--- a/Koco/src/main/java/icet/koco/problemSet/dto/AiSolutionRequestDto.java
+++ b/Koco/src/main/java/icet/koco/problemSet/dto/AiSolutionRequestDto.java
@@ -1,7 +1,9 @@
 package icet.koco.problemSet.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class AiSolutionRequestDto {
     private Long problemNumber;
@@ -9,12 +11,14 @@ public class AiSolutionRequestDto {
     private String problem_solving;
     private SolutionCode solution_code;
 
+	@Builder
     @Getter
     public static class ProblemCheck {
         private String problem_description;
         private String algorithm;
     }
 
+	@Builder
     @Getter
     public static class SolutionCode {
         private String python;

--- a/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetProblemRepository.java
@@ -1,5 +1,6 @@
 package icet.koco.problemSet.repository;
 
+import icet.koco.problemSet.entity.Problem;
 import icet.koco.problemSet.entity.ProblemSet;
 
 import icet.koco.problemSet.entity.ProblemSetProblem;
@@ -31,6 +32,8 @@ public interface ProblemSetProblemRepository extends JpaRepository<ProblemSetPro
 
     @Query("SELECT p.problem.id FROM ProblemSetProblem p WHERE p.problemSet.id = :problemSetId AND p.problem.id IN :problemIds")
     List<Long> findIncludedProblemIds(@Param("problemSetId") Long problemSetId, @Param("problemIds") List<Long> problemIds);
+
+	boolean existsByProblemSetAndProblem(ProblemSet problemSet, Problem problem);
 
 
 }

--- a/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetSolutionRespository.java
+++ b/Koco/src/main/java/icet/koco/problemSet/repository/ProblemSetSolutionRespository.java
@@ -1,7 +1,11 @@
 package icet.koco.problemSet.repository;
 
+import icet.koco.problemSet.entity.Problem;
+import icet.koco.problemSet.entity.ProblemSet;
 import icet.koco.problemSet.entity.ProblemSetSolution;
 import java.util.List;
+
+import icet.koco.problemSet.entity.Solution;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,5 +22,5 @@ public interface ProblemSetSolutionRespository extends JpaRepository<ProblemSetS
     """)
     List<Long> findSolutionIdsByProblemSetId(@Param("problemSetId") Long problemSetId);
 
-
+	boolean existsByProblemSetAndSolution(ProblemSet problemSet, Solution solution);
 }

--- a/Koco/src/main/java/icet/koco/util/test/TestController.java
+++ b/Koco/src/main/java/icet/koco/util/test/TestController.java
@@ -1,6 +1,8 @@
 package icet.koco.util.test;
 
 
+import icet.koco.problemSet.dto.AiSolutionRequestDto;
+import icet.koco.problemSet.service.SolutionService;
 import icet.koco.user.entity.User;
 import icet.koco.user.repository.UserRepository;
 import icet.koco.util.JwtTokenProvider;
@@ -22,12 +24,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/backend/test")
 @Tag(name = "Test", description = "테스트용 API입니다.")
-public class TestAuthController {
+public class TestController {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+	private final SolutionService solutionService;
 
-    @PostMapping("/token")
+
+	@PostMapping("/token")
     @Operation(summary = "테스트용 access_token을 발급하게 하는 API입니다. ")
     public ResponseEntity<?> createTestToken(@RequestParam Long userId) {
         User user = userRepository.findById(userId).orElse(null);
@@ -48,4 +52,25 @@ public class TestAuthController {
 
         return ResponseEntity.ok(result);
     }
+
+	@PostMapping("/mock-solution")
+	@Operation(summary = "AI 서버에서 받아오는 해설 저장 시 매핑 테스트용 API 입니다.")
+	public ResponseEntity<Void> testSaveSolution() {
+		AiSolutionRequestDto mockDto = AiSolutionRequestDto.builder()
+			.problemNumber(30300L)
+			.problem_check(AiSolutionRequestDto.ProblemCheck.builder()
+				.problem_description("예제3 설명입니다.")
+				.algorithm("예제3 알고리즘")
+				.build())
+			.problem_solving("해결 방법 설명")
+			.solution_code(AiSolutionRequestDto.SolutionCode.builder()
+				.cpp("#include <iostream>")
+				.java("public class Main {}")
+				.python("print('hello')")
+				.build())
+			.build();
+
+		solutionService.saveFromAi(mockDto);
+		return ResponseEntity.ok().build();
+	}
 }


### PR DESCRIPTION
## 📝 개요
- 해설 저장 시 문제집 자동 매핑 기능

## 🔗 연관된 이슈
- #125 

## 🔄 변경사항 및 이유
- 현재는 해설 저장이 된 이후 문제집 생성 및 해설, 문제 매핑을 직접 쿼리문으로 하고 있었음.
- 실수 방지 및 자동 매핑을 위해 AI 서버에서 해설 받아와서 저장 시 자동으로 문제집 매핑이 되도록 변경함
 
## 📋 작업할 내용
- [x] 기능 세부 요구사항 정리
- [x] API 수정 (`/api/backend/v1/solution`)
- [x] 백엔드 구현 (`SolutionService.saveFromAi` 자동 매핑)
- [x] 로컬 테스트용 Controller 작성