### PR TITLE
[Feat] SSE 기반 인터뷰 챗봇 구현 (#132)

### DIFF
--- a/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClient.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClient.java
@@ -1,10 +1,10 @@
 package icet.koco.chatbot.client;
 
-import icet.koco.chatbot.dto.feedback.FeedbackAnswerRequestDto;
-import icet.koco.chatbot.dto.feedback.FeedbackStartRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotFollowupRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotStartRequestDto;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface FeedbackSseClient {
-	SseEmitter startFeedbackSession(FeedbackStartRequestDto requestDto);
-	SseEmitter streamFollowupFeedback(FeedbackAnswerRequestDto requestDto);
+	SseEmitter startFeedbackSession(ChatbotStartRequestDto requestDto);
+	SseEmitter streamFollowupFeedback(ChatbotFollowupRequestDto requestDto);
 }

--- a/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
@@ -46,8 +46,6 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 
 	@PostConstruct
 	public void initWebClient() {
-		log.info(">>> AI_BASE_URL 로드됨: {}", baseUrl);
-
 		this.webClient = WebClient.builder()
 			.baseUrl(baseUrl)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
@@ -1,8 +1,8 @@
 package icet.koco.chatbot.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import icet.koco.chatbot.dto.feedback.FeedbackAnswerRequestDto;
-import icet.koco.chatbot.dto.feedback.FeedbackStartRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotFollowupRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotStartRequestDto;
 import icet.koco.chatbot.emitter.ChatEmitterRepository;
 import icet.koco.chatbot.entity.ChatRecord.Role;
 import icet.koco.chatbot.entity.ChatSession;
@@ -55,7 +55,7 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 	}
 
 	@Override
-	public SseEmitter startFeedbackSession(FeedbackStartRequestDto requestDto) {
+	public SseEmitter startFeedbackSession(ChatbotStartRequestDto requestDto) {
 		SseEmitter emitter = new SseEmitter(0L); // 무제한 SSE
 		chatEmitterRepository.save(requestDto.getSessionId(), emitter);
 
@@ -125,7 +125,7 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 	}
 
 	@Override
-	public SseEmitter streamFollowupFeedback(FeedbackAnswerRequestDto requestDto) {
+	public SseEmitter streamFollowupFeedback(ChatbotFollowupRequestDto requestDto) {
 		// SSE emitter 생성
 		SseEmitter emitter = new SseEmitter(0L);
 		chatEmitterRepository.save(requestDto.getSessionId(), emitter);

--- a/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
@@ -56,7 +56,7 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 	public SseEmitter startFeedbackSession(ChatbotStartRequestDto requestDto) {
 		SseEmitter emitter = new SseEmitter(0L); // 무제한 SSE
 		chatEmitterRepository.save(requestDto.getSessionId(), emitter);
-
+		
 		// 요청 내용 로깅
 		try {
 			log.info(">>> [AI 요청] /api/ai/v2/feedback/start 전송 내용:\n{}", objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(requestDto));
@@ -81,7 +81,6 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 			})
 			.doOnNext(event -> {
 				String raw = (String) event.data(); // e.g. "data: Hello"
-//				log.info("SSE 수신 원본: {}", raw);
 
 				String data = raw;
 

--- a/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
@@ -56,7 +56,7 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 	public SseEmitter startFeedbackSession(ChatbotStartRequestDto requestDto) {
 		SseEmitter emitter = new SseEmitter(0L); // 무제한 SSE
 		chatEmitterRepository.save(requestDto.getSessionId(), emitter);
-		
+
 		// 요청 내용 로깅
 		try {
 			log.info(">>> [AI 요청] /api/ai/v2/feedback/start 전송 내용:\n{}", objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(requestDto));

--- a/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClient.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClient.java
@@ -1,0 +1,11 @@
+package icet.koco.chatbot.client;
+
+import icet.koco.chatbot.dto.ai.ChatbotFollowupRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotStartRequestDto;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+
+public interface InterviewSseClient {
+	SseEmitter startInterviewSession(ChatbotStartRequestDto requestDto);
+//	SseEmitter streamFollowupInterview(ChatbotFollowupRequestDto requestDto);
+}

--- a/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClient.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClient.java
@@ -7,5 +7,5 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface InterviewSseClient {
 	SseEmitter startInterviewSession(ChatbotStartRequestDto requestDto);
-//	SseEmitter streamFollowupInterview(ChatbotFollowupRequestDto requestDto);
+	SseEmitter streamFollowupInterview(ChatbotFollowupRequestDto requestDto);
 }

--- a/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClientImpl.java
@@ -121,7 +121,6 @@ public class InterviewSseClientImpl implements InterviewSseClient {
 					}
 					emitter.completeWithError(new RuntimeException(data));
 				} else {
-					log.info("SSE 응답 수신: {}", data);
 					try {
 						emitter.send(SseEmitter.event().name("message").data(data));
 						fullResponse.append(data).append("\n");
@@ -131,7 +130,7 @@ public class InterviewSseClientImpl implements InterviewSseClient {
 				}
 			})
 			.doOnComplete(() -> {
-				log.info("SSE 응답 종료, 전체 응답 저장");
+				log.info("SessionId: {} | SSE 응답 종료, 전체 응답 저장", requestDto.getSessionId());
 				emitter.complete();
 				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
 					.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
@@ -167,7 +166,6 @@ public class InterviewSseClientImpl implements InterviewSseClient {
 			})
 			.doOnNext(event -> {
 				String data = event.data();
-//				log.info("AI 응답 수신: {}", data);
 
 				if (data == null) {
 					log.info("data is null");

--- a/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClientImpl.java
@@ -1,0 +1,153 @@
+package icet.koco.chatbot.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import icet.koco.chatbot.dto.ai.ChatbotStartRequestDto;
+import icet.koco.chatbot.emitter.ChatEmitterRepository;
+import icet.koco.chatbot.entity.ChatRecord.Role;
+import icet.koco.chatbot.entity.ChatSession;
+import icet.koco.chatbot.repository.ChatSessionRepository;
+import icet.koco.chatbot.service.ChatRecordService;
+import icet.koco.enums.ErrorMessage;
+import icet.koco.global.exception.ResourceNotFoundException;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
+
+
+@Component
+@Primary
+@Slf4j
+@RequiredArgsConstructor
+public class InterviewSseClientImpl implements InterviewSseClient {
+
+	@Value("${AI_BASE_URL}")
+	private String baseUrl;
+
+	private final ChatEmitterRepository chatEmitterRepository;
+	private final ChatSessionRepository chatSessionRepository;
+	private final ChatRecordService chatRecordService;
+
+	private WebClient webClient;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@PostConstruct
+	public void initWebClient() {
+		log.info(">>> AI_BASE_URL 로드됨: {}", baseUrl);
+
+		this.webClient = WebClient.builder()
+			.baseUrl(baseUrl)
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.build();
+	}
+
+	/**
+	 * 인터뷰 세션 시작
+	 * @param requestDto
+	 * @return
+	 */
+	@Override
+	public SseEmitter startInterviewSession(ChatbotStartRequestDto requestDto) {
+		SseEmitter emitter = new SseEmitter(0L);
+		chatEmitterRepository.save(requestDto.getSessionId(), emitter);
+
+		try {
+			log.info(">>> [AI 요청] /api/ai/v2/interview/start 전송 내용:\n{}", objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(requestDto));
+		} catch (Exception e) {
+			log.warn("requestDto 직렬화 실패", e);
+		}
+
+
+		StringBuilder fullResponse = new StringBuilder();
+
+		webClient.post()
+			.uri("/api/ai/v2/interview/start")
+			.bodyValue(requestDto)
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.retrieve()
+			.onStatus(status -> status.is5xxServerError(), response -> {
+				// AI 서버 내부 오류 발생 시 로그 출력
+				return response.bodyToMono(String.class)
+					.doOnNext(errorBody -> {
+						log.error("AI 서버 500 응답 수신: {}", errorBody);
+					})
+					.thenReturn(new RuntimeException("AI 서버 오류: 500"));
+			})
+			.onStatus(status -> status.is4xxClientError(), response -> {
+				return response.bodyToMono(String.class)
+					.doOnNext(errorBody -> {
+						log.warn("AI 서버 4xx 응답 수신: {}", errorBody);
+					})
+					.thenReturn(new RuntimeException("AI 서버 요청 오류: 4xx"));
+			})
+			.bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
+			.filter(event -> event.data() != null)
+			.timeout(Duration.ofSeconds(60))
+			.onErrorResume(e -> {
+				log.error("SSE 통신 중 에러 발생: {}", e.getMessage(), e);
+				emitter.completeWithError(e);
+				return Flux.empty();
+			})
+			.doOnNext(event -> {
+				String raw = event.data();
+
+				String data = raw;
+				if (data == null) {
+					log.info("SSE 데이터 null");
+					return;
+				}
+
+				if (data.startsWith("data: ")) {
+					data = data.substring(6);
+				}
+
+				if (data.startsWith("[ERROR]")) {
+					log.warn("SSE 응답 오류 감지: {}", data);
+					try {
+						emitter.send(SseEmitter.event().name("error").data(data));
+					} catch (IOException e) {
+						emitter.completeWithError(e);
+						return;
+					}
+					emitter.completeWithError(new RuntimeException(data));
+				} else {
+					log.info("SSE 응답 수신: {}", data);
+					try {
+						emitter.send(SseEmitter.event().name("message").data(data));
+						fullResponse.append(data).append("\n");
+					} catch (IOException e) {
+						emitter.completeWithError(e);
+					}
+				}
+			})
+			.doOnComplete(() -> {
+				log.info("SSE 응답 종료, 전체 응답 저장");
+				emitter.complete();
+				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+					.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
+				chatRecordService.save(chatSession, Role.assistant, fullResponse.toString().trim());
+			})
+			.subscribe();
+
+
+		return emitter;
+
+	}
+
+//	@Override
+//	public SseEmitter streamFollowupInterview(ChatbotFollowupRequestDto requestDto) {
+//
+//	};
+
+}

--- a/Koco/src/main/java/icet/koco/chatbot/client/MockFeedbackSseClient.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/MockFeedbackSseClient.java
@@ -1,18 +1,16 @@
 package icet.koco.chatbot.client;
 
-import icet.koco.chatbot.dto.feedback.FeedbackAnswerRequestDto;
-import icet.koco.chatbot.dto.feedback.FeedbackStartRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotFollowupRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotStartRequestDto;
 import icet.koco.chatbot.emitter.ChatEmitterRepository;
 import icet.koco.chatbot.entity.ChatRecord.Role;
 import icet.koco.chatbot.entity.ChatSession;
-import icet.koco.chatbot.repository.ChatRecordRepository;
 import icet.koco.chatbot.repository.ChatSessionRepository;
 import icet.koco.chatbot.service.ChatRecordService;
 import icet.koco.enums.ErrorMessage;
 import icet.koco.global.exception.ResourceNotFoundException;
 import icet.koco.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -27,7 +25,7 @@ public class MockFeedbackSseClient implements FeedbackSseClient {
 	private final CookieUtil cookieUtil;
 
 	@Override
-	public SseEmitter startFeedbackSession(FeedbackStartRequestDto requestDto) {
+	public SseEmitter startFeedbackSession(ChatbotStartRequestDto requestDto) {
 		System.out.println("MOCK 세션 생성 - sessionId: " + requestDto.getSessionId());
 
 		// emitter 연결 무제한
@@ -72,7 +70,7 @@ public class MockFeedbackSseClient implements FeedbackSseClient {
 	}
 
 	@Override
-	public SseEmitter streamFollowupFeedback(FeedbackAnswerRequestDto requestDto) {
+	public SseEmitter streamFollowupFeedback(ChatbotFollowupRequestDto requestDto) {
 		System.out.println("MockFeedbackSseClient: streamAnswer(후속 질문 AI)");
 
 		SseEmitter emitter = new SseEmitter(0L); // 무제한

--- a/Koco/src/main/java/icet/koco/chatbot/client/MockSummaryClient.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/MockSummaryClient.java
@@ -3,7 +3,6 @@ package icet.koco.chatbot.client;
 import icet.koco.chatbot.dto.summary.ChatSummaryRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/Koco/src/main/java/icet/koco/chatbot/client/SummaryClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/SummaryClientImpl.java
@@ -5,7 +5,6 @@ import icet.koco.chatbot.dto.summary.ChatSummaryResponseDto;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.minidev.json.JSONUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpHeaders;

--- a/Koco/src/main/java/icet/koco/chatbot/client/SummaryClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/SummaryClientImpl.java
@@ -28,8 +28,6 @@ public class SummaryClientImpl implements SummaryClient {
 
 	@PostConstruct
 	public void initWebClient() {
-		log.info(">>> AI_BASE_URL 로드됨: {}", baseUrl);
-
 		this.webClient = WebClient.builder()
 			.baseUrl(baseUrl)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
+++ b/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
@@ -27,6 +27,8 @@ public class ChatSessionController {
 
 		if (mode.equals("feedback")) {
 			return chatSessionService.startFeedbackSession(requestDto, userId);
+		} else if (mode.equals("interview")) {
+			return chatSessionService.startInterviewSession(requestDto, userId);
 		}
 		return null;
 	}

--- a/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
+++ b/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
@@ -2,11 +2,13 @@ package icet.koco.chatbot.controller;
 
 import icet.koco.chatbot.dto.ChatSessionStartRequestDto;
 import icet.koco.chatbot.dto.UserMessageRequestDto;
+import icet.koco.chatbot.entity.ChatSession;
+import icet.koco.chatbot.repository.ChatSessionRepository;
 import icet.koco.chatbot.service.ChatSessionService;
-import jakarta.servlet.http.HttpServletResponse;
+import icet.koco.enums.ErrorMessage;
+import icet.koco.global.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -17,6 +19,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class ChatSessionController {
 
 	private final ChatSessionService chatSessionService;
+	private final ChatSessionRepository chatSessionRepository;
 
 	@PostMapping(value = "/session", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public SseEmitter startChatSession(@RequestBody ChatSessionStartRequestDto requestDto) {
@@ -38,6 +41,27 @@ public class ChatSessionController {
 											@RequestBody UserMessageRequestDto requestDto) {
 		Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
-		return chatSessionService.processUserMessage(sessionId, userId, requestDto.getContent());
+		String mode = getMode(sessionId).toString();
+
+		if (mode.equals("feedback")) {
+			System.out.println("ChatSessionController.sendMessage - feedback");
+			return chatSessionService.followupFeedbackSession(sessionId, userId, requestDto.getContent());
+		} else if (mode.equals("interview")) {
+			System.out.println("ChatSessionController.sendMessage - interview");
+			return chatSessionService.followupInterviewSession(sessionId, userId, requestDto.getContent());
+		}
+		return null;
+	}
+
+	/**
+	 * 세션의 모드를 구함
+	 * @param sessionId 세션id
+	 * @return ChatSession.Mode
+	 */
+	public ChatSession.Mode getMode(Long sessionId) {
+		ChatSession chatSession = chatSessionRepository.findById(sessionId)
+			.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
+
+		return chatSession.getMode();
 	}
 }

--- a/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
+++ b/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
@@ -23,7 +23,6 @@ public class ChatSessionController {
 
 	@PostMapping(value = "/session", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public SseEmitter startChatSession(@RequestBody ChatSessionStartRequestDto requestDto) {
-		System.out.println("ChatSessionController.startChatSession");
 		Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
 		String mode = (requestDto.getMode()).toString();
@@ -44,10 +43,8 @@ public class ChatSessionController {
 		String mode = getMode(sessionId).toString();
 
 		if (mode.equals("feedback")) {
-			System.out.println("ChatSessionController.sendMessage - feedback");
 			return chatSessionService.followupFeedbackSession(sessionId, userId, requestDto.getContent());
 		} else if (mode.equals("interview")) {
-			System.out.println("ChatSessionController.sendMessage - interview");
 			return chatSessionService.followupInterviewSession(sessionId, userId, requestDto.getContent());
 		}
 		return null;

--- a/Koco/src/main/java/icet/koco/chatbot/controller/InterviewController.java
+++ b/Koco/src/main/java/icet/koco/chatbot/controller/InterviewController.java
@@ -1,0 +1,27 @@
+package icet.koco.chatbot.controller;
+
+import icet.koco.chatbot.dto.ai.InterviewEndRequestDto;
+import icet.koco.chatbot.service.InterviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Interview", description = "AI서버로부터 종료 여부 수신")
+@RequestMapping("/api/backend/v2/chat/interview/end")
+@RequiredArgsConstructor
+@RestController
+public class InterviewController {
+	private final InterviewService interviewService;
+
+	@Operation(summary = "AI서버로부터 인터뷰 종료 여부 저장")
+	@PostMapping
+	public ResponseEntity<?> interviewEndCheck(@RequestBody InterviewEndRequestDto requestDto) {
+		interviewService.interviewEndCheck(requestDto);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/Koco/src/main/java/icet/koco/chatbot/dto/ai/ChatbotFollowupRequestDto.java
+++ b/Koco/src/main/java/icet/koco/chatbot/dto/ai/ChatbotFollowupRequestDto.java
@@ -1,4 +1,4 @@
-package icet.koco.chatbot.dto.feedback;
+package icet.koco.chatbot.dto.ai;
 
 import icet.koco.chatbot.entity.ChatRecord;
 import lombok.AllArgsConstructor;
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class FeedbackAnswerRequestDto {
+public class ChatbotFollowupRequestDto {
 	private Long sessionId;
 	private String summary;
 	private List<Message> messages;
@@ -25,12 +25,12 @@ public class FeedbackAnswerRequestDto {
 		private String content;
 	}
 
-	public static FeedbackAnswerRequestDto from(Long sessionId, String summary, List<ChatRecord> messages) {
+	public static ChatbotFollowupRequestDto from(Long sessionId, String summary, List<ChatRecord> messages) {
 		List<Message> messageList = messages.stream()
 				.map(r -> new Message(r.getRole().name(), r.getContent()))
 				.collect(Collectors.toList());
 
-		return FeedbackAnswerRequestDto.builder()
+		return ChatbotFollowupRequestDto.builder()
 				.sessionId(sessionId)
 				.summary(summary)
 				.messages(messageList)

--- a/Koco/src/main/java/icet/koco/chatbot/dto/ai/ChatbotStartRequestDto.java
+++ b/Koco/src/main/java/icet/koco/chatbot/dto/ai/ChatbotStartRequestDto.java
@@ -1,4 +1,4 @@
-package icet.koco.chatbot.dto.feedback;
+package icet.koco.chatbot.dto.ai;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class FeedbackStartRequestDto {
+public class ChatbotStartRequestDto {
 	private Long sessionId;
 	private Long problemNumber;
 	private String title;

--- a/Koco/src/main/java/icet/koco/chatbot/dto/ai/InterviewEndRequestDto.java
+++ b/Koco/src/main/java/icet/koco/chatbot/dto/ai/InterviewEndRequestDto.java
@@ -1,0 +1,12 @@
+package icet.koco.chatbot.dto.ai;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InterviewEndRequestDto {
+	private Long sessionId;
+
+	private boolean finished;
+}

--- a/Koco/src/main/java/icet/koco/chatbot/entity/ChatRecord.java
+++ b/Koco/src/main/java/icet/koco/chatbot/entity/ChatRecord.java
@@ -2,8 +2,7 @@ package icet.koco.chatbot.entity;
 
 
 import icet.koco.chatbot.dto.ChatSessionStartRequestDto;
-import icet.koco.chatbot.dto.feedback.FeedbackAnswerRequestDto;
-import icet.koco.chatbot.dto.feedback.FeedbackStartRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotFollowupRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -66,10 +65,10 @@ public class ChatRecord {
 	}
 
 
-	public static List<ChatRecord> fromAnswerDto(FeedbackAnswerRequestDto dto, ChatSession session) {
+	public static List<ChatRecord> fromAnswerDto(ChatbotFollowupRequestDto dto, ChatSession session) {
 		List<ChatRecord> records = new ArrayList<>();
 		int turn = 1;
-		for (FeedbackAnswerRequestDto.Message m : dto.getMessages()) {
+		for (ChatbotFollowupRequestDto.Message m : dto.getMessages()) {
 			records.add(ChatRecord.builder()
 				.chatSession(session)
 				.turn(turn++)

--- a/Koco/src/main/java/icet/koco/chatbot/entity/ChatSession.java
+++ b/Koco/src/main/java/icet/koco/chatbot/entity/ChatSession.java
@@ -4,8 +4,6 @@ package icet.koco.chatbot.entity;
 import icet.koco.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 
 import java.time.LocalDateTime;
@@ -44,8 +42,8 @@ public class ChatSession {
 	private LocalDateTime deletedAt;
 
 	// 해당 세션이 종료되었는지 (AI 에이전트에서 판단한 값)
-	@Column(name = "is_finished")
-	private Boolean finished;
+	@Column(name = "is_finished", nullable = false)
+	private Boolean finished = Boolean.FALSE;
 
 	public enum Mode {
 		feedback, interview;

--- a/Koco/src/main/java/icet/koco/chatbot/service/ChatSessionService.java
+++ b/Koco/src/main/java/icet/koco/chatbot/service/ChatSessionService.java
@@ -49,9 +49,6 @@ public class ChatSessionService {
 		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
 				.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND));
 
-		log.info("User: " + user.getNickname());
-		log.info("Mode: " + dto.getMode());
-
 		// 문제 찾기
 		Problem problem = problemRepository.findByNumber(dto.getProblemNumber())
 				.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.PROBLEM_NOT_FOUND));
@@ -107,7 +104,7 @@ public class ChatSessionService {
 		boolean shouldUpdateSummary = (totalCount == 3 || totalCount % 11 == 0);
 
 		if (shouldUpdateSummary) {
-			System.out.println("summary 요청 | totalCount: " + totalCount);
+			// 새로운 summary 요청
 			List<ChatRecord> latestMessages = chatRecordRepository.findLast10BySessionId(sessionId);
 			ChatSummaryRequestDto summaryDto = ChatSummaryRequestDto.from(sessionId, latestMessages);
 
@@ -115,7 +112,6 @@ public class ChatSessionService {
 			saveOrUpdateSummary(session, summary);
 		} else {
 			// 기존 summary 가져오기
-			System.out.println("summary 요청하지 않음 | totalCount: " + totalCount);
 			summary = chatSummaryRepository.findByChatSession(session)
 					.map(ChatSummary::getSummary)
 					.orElse("");
@@ -128,13 +124,9 @@ public class ChatSessionService {
 	}
 
 	public SseEmitter startInterviewSession(ChatSessionStartRequestDto dto, Long userId) {
-		log.info("startInterviewSession - userId: " + userId);
 		// 사용자 찾기
 		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
 			.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND));
-
-		log.info("User: " + user.getNickname());
-		log.info("Mode: " + dto.getMode());
 
 		// 문제 찾기
 		Problem problem = problemRepository.findByNumber(dto.getProblemNumber())
@@ -172,7 +164,6 @@ public class ChatSessionService {
 	}
 
 	public SseEmitter followupInterviewSession(Long sessionId, Long userId, String content) {
-		log.info("FollowupInterviewSession - sessionId: " + sessionId + ", userId: " + userId);
 		// 사용자 있는지 확인
 		userRepository.findByIdAndDeletedAtIsNull(userId)
 				.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND));
@@ -193,14 +184,12 @@ public class ChatSessionService {
 		boolean shouldUpdateSummary = (totalCount == 3 || totalCount % 11 == 0);
 
 		if (shouldUpdateSummary) {
-			log.info("요약 요청, totalCount: " + totalCount);
 			List<ChatRecord> latestMessages = chatRecordRepository.findLast10BySessionId(sessionId);
 			ChatSummaryRequestDto summaryDto = ChatSummaryRequestDto.from(sessionId, latestMessages);
 
 			summary = summaryClient.requestSummary(summaryDto);
 		} else {
 			// 기존 summary 사용
-			log.info("summary 요청하지 않음, totalCount: " + totalCount);
 			summary = chatSummaryRepository.findByChatSession(chatSession)
 					.map(ChatSummary::getSummary)
 					.orElse("");
@@ -227,7 +216,6 @@ public class ChatSessionService {
 					.build();
 			chatSummaryRepository.save(newOne);
 		}
-		System.out.println("summary 저장 또는 업데이트 완료");
 	}
 
 }

--- a/Koco/src/main/java/icet/koco/chatbot/service/ChatSessionService.java
+++ b/Koco/src/main/java/icet/koco/chatbot/service/ChatSessionService.java
@@ -3,8 +3,8 @@ package icet.koco.chatbot.service;
 import icet.koco.chatbot.client.FeedbackSseClient;
 import icet.koco.chatbot.client.SummaryClient;
 import icet.koco.chatbot.dto.ChatSessionStartRequestDto;
-import icet.koco.chatbot.dto.feedback.FeedbackAnswerRequestDto;
-import icet.koco.chatbot.dto.feedback.FeedbackStartRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotFollowupRequestDto;
+import icet.koco.chatbot.dto.ai.ChatbotStartRequestDto;
 import icet.koco.chatbot.dto.summary.ChatSummaryRequestDto;
 import icet.koco.chatbot.entity.ChatRecord;
 import icet.koco.chatbot.entity.ChatSession;
@@ -68,7 +68,7 @@ public class ChatSessionService {
 		chatRecordRepository.saveAll(initRecord);
 
 		// AI 피드백 요청
-		FeedbackStartRequestDto request = FeedbackStartRequestDto.builder()
+		ChatbotStartRequestDto request = ChatbotStartRequestDto.builder()
 				.sessionId(session.getId())
 				.problemNumber(dto.getProblemNumber())
 				.title(problem.getTitle())
@@ -119,7 +119,7 @@ public class ChatSessionService {
 
 		// 후속 피드백 요청
 		List<ChatRecord> latestMessages = chatRecordRepository.findLast10BySessionId(sessionId);
-		FeedbackAnswerRequestDto answerRequest = FeedbackAnswerRequestDto.from(sessionId, summary, latestMessages);
+		ChatbotFollowupRequestDto answerRequest = ChatbotFollowupRequestDto.from(sessionId, summary, latestMessages);
 		return feedbackSseClient.streamFollowupFeedback(answerRequest);
 	}
 

--- a/Koco/src/main/java/icet/koco/chatbot/service/InterviewService.java
+++ b/Koco/src/main/java/icet/koco/chatbot/service/InterviewService.java
@@ -1,0 +1,27 @@
+package icet.koco.chatbot.service;
+
+import icet.koco.chatbot.dto.ai.InterviewEndRequestDto;
+import icet.koco.chatbot.entity.ChatSession;
+import icet.koco.chatbot.repository.ChatSessionRepository;
+import icet.koco.enums.ErrorMessage;
+import icet.koco.global.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewService {
+	private final ChatSessionRepository chatSessionRepository;
+
+	public void interviewEndCheck(InterviewEndRequestDto requestDto) {
+		ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+			.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
+
+		boolean isEnded = requestDto.isFinished();
+		System.out.println("해당 세션 종료되었는지 여부: " + isEnded);
+
+		// 채팅 세션 상태 저장
+		chatSession.setFinished(isEnded);
+		chatSessionRepository.save(chatSession);
+	}
+}

--- a/Koco/src/main/java/icet/koco/enums/ErrorMessage.java
+++ b/Koco/src/main/java/icet/koco/enums/ErrorMessage.java
@@ -7,6 +7,8 @@ public enum ErrorMessage {
     // 400 (Bad Request - BadRequestException)
     INVALID_CATEGORY_INCLUDED("존재하지 않는 카테고리가 포함되어 있습니다."),
     INVALID_PROBLEM_INCLUDED("해당 문제 번호를 가진 백준 문제가 없습니다."),
+	INTERVIEW_ALREADY_FINISHED("이미 종료된 면접 세션입니다."),
+
 
     // 401 (Unauthorized - UnauthorizedException)
 	INVALID_ACCESS_TOKEN("유효하지 않은 access token 입니다."),

--- a/Koco/src/main/java/icet/koco/global/exception/InterviewAlreadyFinishedException.java
+++ b/Koco/src/main/java/icet/koco/global/exception/InterviewAlreadyFinishedException.java
@@ -1,0 +1,20 @@
+package icet.koco.global.exception;
+
+import icet.koco.enums.ErrorMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InterviewAlreadyFinishedException extends RuntimeException {
+	private final ErrorMessage errorMessage;
+
+	public InterviewAlreadyFinishedException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+		this.errorMessage = null;
+	}
+
+	public InterviewAlreadyFinishedException(String message) {
+		super(message);
+		this.errorMessage = null;
+	}
+}

--- a/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
+++ b/Koco/src/main/java/icet/koco/util/JwtAuthenticationFilter.java
@@ -41,7 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.equals("/api/backend/v1/auth/refresh")
                 || path.equals("/api/backend/v1/auth/callback")
                 || path.equals("/oauth/kakao/callback")
-//                || path.startsWith("/api/backend/v2/chat")
+				|| path.equals("/api/backend/v2/chat/interview/end")
                 || path.equals("/api/backend/admin/today/problem-set")
                 || path.equals("/api/backend/test/token")
                 || path.equals("/api/backend/test/timezone")


### PR DESCRIPTION
## 📝 개요
- Spring Boot + WebClient + SseEmitter 기반으로 실시간 코드 인터뷰 챗봇을 구현하였습니다.
- 사용자가 대화 세션을 시작하면 AI 서버에 최초 인터뷰 요청을 보내고, 해당 응답을 스트리밍 형식(SSE)으로 프론트엔드에 전달합니다.
- 이후 사용자 후속 질문에 대해서도 스트리밍 응답을 받아 챗봇 대화가 이어지도록 처리하였습니다.
- 메시지 10개마다 요약(summary)을 자동으로 요청하여, 중간 요약 저장 기능도 포함했습니다.
- AI가 사용자의 응답을 판단하여 면접을 종료하면 종료 여부를 받는 엔드포인트를 열어놓았습니다. 

## 🔗 연관된 이슈
- #132 

## 🔄 변경사항 및 이유
- `InterviewSseClient` 구현: `/api/ai/v2/interview/start` SSE 요청 처리
- `ChatSessionService` 분리 및 도메인 책임 위임 (세션 관리, 메시지 흐름)
- `ChatEmitterRepository`: sessionId ↔ SseEmitter 매핑 저장소
- feedback, interview에 대해서 햇봇 분기

## 📋 작업할 내용
- [x] 기능 세부 요구사항 정리
- [x] API 설계 (`/api/backend/v2/chat/session`, `/session/{sessionId}`, `/api/v1/interview/answer`)
- [x] 백엔드 구현 (WebClient + SseEmitter)
- [x] 배포 및 실제 SSE 테스트 완료 (실제 AI 서버)
