### PR TITLE
[Feat] 채팅 세션 삭제 API 구현 (#139)

### DIFF
--- a/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/FeedbackSseClientImpl.java
@@ -112,7 +112,7 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 			})
 			.doOnComplete(() -> {
 				emitter.complete();
-				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+				ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(requestDto.getSessionId())
 					.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 				chatRecordService.save(chatSession, Role.assistant, fullResponse.toString().trim());
 			})
@@ -168,7 +168,7 @@ public class FeedbackSseClientImpl implements FeedbackSseClient {
 				emitter.complete();
 
 				// ChatSession 조회
-				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+				ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(requestDto.getSessionId())
 					.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 				// ChatRecord 저장

--- a/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClientImpl.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/InterviewSseClientImpl.java
@@ -132,7 +132,7 @@ public class InterviewSseClientImpl implements InterviewSseClient {
 			.doOnComplete(() -> {
 				log.info("SessionId: {} | SSE 응답 종료, 전체 응답 저장", requestDto.getSessionId());
 				emitter.complete();
-				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+				ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(requestDto.getSessionId())
 					.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 				chatRecordService.save(chatSession, Role.assistant, fullResponse.toString().trim());
 			})
@@ -190,7 +190,7 @@ public class InterviewSseClientImpl implements InterviewSseClient {
 				emitter.complete();
 
 				// ChatSession 조회
-				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+				ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(requestDto.getSessionId())
 					.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 				// ChatRecord 저장

--- a/Koco/src/main/java/icet/koco/chatbot/client/MockFeedbackSseClient.java
+++ b/Koco/src/main/java/icet/koco/chatbot/client/MockFeedbackSseClient.java
@@ -54,7 +54,7 @@ public class MockFeedbackSseClient implements FeedbackSseClient {
 				emitter.complete();
 
 				// chatSession 조회
-				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+				ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(requestDto.getSessionId())
 					.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 				// chatRecord 저장
@@ -92,7 +92,7 @@ public class MockFeedbackSseClient implements FeedbackSseClient {
 				emitter.complete();
 
 				// chatSession 조회
-				ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+				ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(requestDto.getSessionId())
 						.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 				// chatRecord 저장

--- a/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
+++ b/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
@@ -19,6 +19,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RestController
 @RequestMapping("/api/backend/v2/chat")
 @Tag(name = "ChatBot", description = "챗봇 관련 API입니다.")
@@ -66,6 +70,34 @@ public class ChatSessionController {
 			return chatSessionService.followupInterviewSession(sessionId, userId, requestDto.getContent());
 		}
 		return null;
+	}
+
+	/**
+	 * 세션 삭제 API
+	 * @param sessionIdsHeader RequestHeader의 sessionId
+	 * @return	204
+	 */
+	@DeleteMapping("/session/delete")
+	@Operation(summary = "선택한 챗봇 세션을 삭제하는 API입니다.")
+	public ResponseEntity<?> deleteChatSession( @RequestHeader("Session-Ids") String sessionIdsHeader) {
+		Long userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+		System.out.println(sessionIdsHeader);
+
+		if (sessionIdsHeader == null || sessionIdsHeader.trim().isEmpty()) {
+			throw new IllegalArgumentException("Session-Ids 헤더가 비어있습니다.");
+		}
+
+		List<Long> sessionIds = Arrays.stream(sessionIdsHeader.split(", "))
+			.map(String::trim)
+			.map(Long::parseLong)
+			.collect(Collectors.toList());
+
+		System.out.println("sessionIds: " + sessionIds);
+
+		chatSessionService.deleteChatSessions(userId, sessionIds);
+
+		return ResponseEntity.noContent().build();
 	}
 
 	/**

--- a/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
+++ b/Koco/src/main/java/icet/koco/chatbot/controller/ChatSessionController.java
@@ -106,7 +106,7 @@ public class ChatSessionController {
 	 * @return ChatSession.Mode
 	 */
 	public String getMode(Long sessionId) {
-		ChatSession chatSession = chatSessionRepository.findById(sessionId)
+		ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(sessionId)
 			.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 		return chatSession.getMode().toString();

--- a/Koco/src/main/java/icet/koco/chatbot/entity/ChatSession.java
+++ b/Koco/src/main/java/icet/koco/chatbot/entity/ChatSession.java
@@ -48,6 +48,7 @@ public class ChatSession {
 	private LocalDateTime deletedAt;
 
 	// 해당 세션이 종료되었는지 (AI 에이전트에서 판단한 값)
+	@Builder.Default
 	@Column(name = "is_finished", nullable = false)
 	private Boolean finished = Boolean.FALSE;
 

--- a/Koco/src/main/java/icet/koco/chatbot/repository/ChatSessionRepository.java
+++ b/Koco/src/main/java/icet/koco/chatbot/repository/ChatSessionRepository.java
@@ -3,9 +3,13 @@ package icet.koco.chatbot.repository;
 import icet.koco.chatbot.entity.ChatSession;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
 	// sessionId로 세션 찾기
 	Optional<ChatSession> findByIdAndDeletedAtIsNull(Long id);
+
+	List<ChatSession> findAllByIdInAndDeletedAtIsNull(List<Long> ids);
+
 }

--- a/Koco/src/main/java/icet/koco/chatbot/service/ChatSessionService.java
+++ b/Koco/src/main/java/icet/koco/chatbot/service/ChatSessionService.java
@@ -125,7 +125,7 @@ public class ChatSessionService {
 				.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND));
 
 		// 채팅 세션 찾기
-		ChatSession session = chatSessionRepository.findById(sessionId)
+		ChatSession session = chatSessionRepository.findByIdAndDeletedAtIsNull(sessionId)
 				.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 		// 유저가 보낸 메시지 저장
@@ -200,7 +200,7 @@ public class ChatSessionService {
 				.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.USER_NOT_FOUND));
 
 		// 채팅 세션 찾기
-		ChatSession chatSession = chatSessionRepository.findById(sessionId)
+		ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(sessionId)
 				.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 		// 종료된 세션이면 예외

--- a/Koco/src/main/java/icet/koco/chatbot/service/InterviewService.java
+++ b/Koco/src/main/java/icet/koco/chatbot/service/InterviewService.java
@@ -14,7 +14,7 @@ public class InterviewService {
 	private final ChatSessionRepository chatSessionRepository;
 
 	public void interviewEndCheck(InterviewEndRequestDto requestDto) {
-		ChatSession chatSession = chatSessionRepository.findById(requestDto.getSessionId())
+		ChatSession chatSession = chatSessionRepository.findByIdAndDeletedAtIsNull(requestDto.getSessionId())
 			.orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.CHAT_SESSION_NOT_FOUND));
 
 		boolean isEnded = requestDto.isFinished();


### PR DESCRIPTION
# TITLE
[Feat] 회원가입 기능 구현 (#이슈번호)

## 📝 개요
- 사용자가 선택한 챗봇 세션을 삭제할 수 있도록 하는 백엔드 API를 구현하였습니다.  
- Soft Delete 방식(`deletedAt` 필드 갱신)으로 데이터 정합성과 추후 복구 가능성을 고려했습니다.

## 🔗 연관된 이슈
- #139

## 🔄 변경사항 및 이유
- `ChatSessionController`에 `@DeleteMapping("/session/delete")` API 추가  
- 헤더로 전달된 `Session-Ids`를 파싱하여 사용자의 세션만 필터링하여 soft delete 처리  
- `ChatSessionService` 내 세션 ID 유효성 검사, 사용자 검증, soft delete 로직 추가  
- `finished` 필드 미초기화로 인한 JPA 예외 방지를 위해 해당 필드에 기본값 설정  
- 기존 조회 로직들과 일관성 있게 `deletedAt`이 null인 데이터만 조회되도록 처리 유지

## 📋 작업할 내용
- [x] API 설계
- [x] 백엔드 구현

## 👀 리뷰 요구사항 (선택)
- `Session-Ids`를 Request Header로 받는 방식이 적절한가

